### PR TITLE
Add netcat as a requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You also need to install the following packages on your distribution:
 
 * *qemu-system-x86_64*
 * *curl* or *wget*
+* *netcat*
 
 
 ## How to build


### PR DESCRIPTION
netcat is required by the install script in order to test CoreOS's boot
