### PR TITLE
Optimise packer build qemu parameters

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/net-opti.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/net-opti.ps1
@@ -1,2 +1,0 @@
-cd "C:\Windows\Microsoft.NET\Framework\v4.0.30319"
-.\ngen.exe executequeueditems

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -79,7 +79,6 @@
                             "floppy/windows-2012-standard-amd64/Disable-WU.ps1",
                             "floppy/windows-2012-standard-amd64/AD-install.ps1",
                             "floppy/windows-2012-standard-amd64/enable-RDP.ps1",
-                            "floppy/windows-2012-standard-amd64/net-opti.ps1",
                             "floppy/windows-2012-standard-amd64/RDS-install.ps1"
 
             ]

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -53,8 +53,8 @@
             "disk_size": "{{ user `disk_size`}}",
             "disk_interface":"virtio",
             "qemuargs": [
-                           [ "-m", "2560"],
-                           [ "-smp", "2"]
+                           [ "-m", "4096"],
+                           [ "-smp", "4"]
                         ],
             "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
             "iso_checksum_type": "md5",


### PR DESCRIPTION
net-opti.ps1 make the build to fail
Allow qemu to take more resources during the build
