### PR TITLE
Remove cerficate upload in windows build

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/upload-cert.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/upload-cert.ps1
@@ -1,4 +1,0 @@
-$url = "http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe"
-$output = "c:\windows\system32\pscp.exe"
-Invoke-WebRequest -Uri $url -OutFile $output
-echo n | C:\Windows\System32\pscp.exe -q -pw PASSWORD "C:\Users\Administrator\ad2012.cer" USER@HOST:PATH

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -86,7 +86,7 @@
         {
              "type": "file",
              "source": "floppy/windows-2012-standard-amd64/publishApplication.ps1",
-             "destination": "c:"
+             "destination": "C:\\"
         },
         {
             "type": "windows-restart"

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -96,7 +96,6 @@
              "scripts": [
                             "floppy/windows-2012-standard-amd64/AD-create-OU.ps1",
                             "floppy/windows-2012-standard-amd64/adcs-cert.ps1",
-                            "floppy/windows-2012-standard-amd64/upload-cert.ps1",
                             "floppy/windows-2012-standard-amd64/prepareWindows.ps1"
              ],
              "pause_before": "120s"


### PR DESCRIPTION
Current certificate generation expected to find a Nanocloud API to upload the certificate. Community should work the other way around: 

First certificate is generate on Windows during provision
Then certificate is downloaded by Nanocloud after VM booted
