### PR TITLE
Do not provision windows with publish script

### DIFF
--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -84,10 +84,6 @@
             ]
         },
         {
-             "type": "file",
-             "source": "floppy/windows-2012-standard-amd64/publishApplication.ps1",
-             "destination": "C:\\"
-        },
         {
             "type": "windows-restart"
         },     

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -84,11 +84,6 @@
             ]
         },
         {
-             "type": "file",
-             "source": "floppy/windows-2012-standard-amd64/publishApplication.ps1",
-             "destination": "C:\\"
-        },
-        {
             "type": "windows-restart"
         },     
         {


### PR DESCRIPTION
Do not provide Windows with publish script.
It should be copied later by API
