### PR TITLE
Windows provisionning now used mirrors.kernel.org as cygwin mirror

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/configure.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/configure.ps1
@@ -1,3 +1,3 @@
 mkdir C:\cygwin
 Invoke-WebRequest https://community.nanocloud.com/cygwin/setup-x86_64.exe -OutFile C:\cygwin\cygwin-setup-x86_64.exe
-C:\cygwin\cygwin-setup-x86_64.exe -a x86_64 -q -R C:\cygwin -P openssh -s http://mirrors.chauf.net/cygwin
+C:\cygwin\cygwin-setup-x86_64.exe -a x86_64 -q -R C:\cygwin -P openssh -s http://mirrors.kernel.org/sourceware/cygwin


### PR DESCRIPTION
mirrors.chauf.net is a French mirror and seems to be unstable often leading to build fail. We should use the well know mirror from kernel.org
