### PR TITLE
Copy Cygwin installation script during build instead of provisioning

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/Autounattend.xml
+++ b/windows/floppy/windows-2012-standard-amd64/Autounattend.xml
@@ -127,13 +127,14 @@
       </AutoLogon>
 
       <FirstLogonCommands>
-      
-      <SynchronousCommand wcm:action="add">
-          <CommandLine>cmd /c a:\configure.bat</CommandLine>
-          <Description>Run configure script</Description>
-          <Order>1</Order>
-        </SynchronousCommand>
-      
+
+       <SynchronousCommand wcm:action="add">
+         <CommandLine>c:\windows\system32\WindowsPowerShell\v1.0\powershell.exe "cp a:\\install-cygwin-sshd.sh C:\\install-cygwin-sshd.sh"</CommandLine>
+         <Description>Copy cygwin script</Description>
+         <Order>1</Order>
+         <RequiresUserInput>true</RequiresUserInput>
+       </SynchronousCommand>
+
       <SynchronousCommand wcm:action="add">
          <CommandLine>c:\windows\system32\WindowsPowerShell\v1.0\powershell.exe a:\configure-winrm.ps1</CommandLine>
          <Description>Configure WinRM</Description>

--- a/windows/floppy/windows-2012-standard-amd64/Autounattend.xml
+++ b/windows/floppy/windows-2012-standard-amd64/Autounattend.xml
@@ -127,13 +127,15 @@
       </AutoLogon>
 
       <FirstLogonCommands>
-      
-      <SynchronousCommand wcm:action="add">
-          <CommandLine>cmd /c a:\configure.bat</CommandLine>
-          <Description>Run configure script</Description>
-          <Order>1</Order>
-        </SynchronousCommand>
-      
+
+
+       <SynchronousCommand wcm:action="add">
+         <CommandLine>c:\windows\system32\WindowsPowerShell\v1.0\powershell.exe "cp a:\\install-cygwin-sshd.sh C:\\install-cygwin-sshd.sh"</CommandLine>
+         <Description>Copy cygwin script</Description>
+         <Order>1</Order>
+         <RequiresUserInput>true</RequiresUserInput>
+       </SynchronousCommand>
+
       <SynchronousCommand wcm:action="add">
          <CommandLine>c:\windows\system32\WindowsPowerShell\v1.0\powershell.exe a:\configure-winrm.ps1</CommandLine>
          <Description>Configure WinRM</Description>

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -65,16 +65,12 @@
 			"floppy_files": [
 				"floppy/drivers/virtio-win-0.1-81/WIN7/AMD64/*",
 				"floppy/windows-2012-standard-amd64/Autounattend.xml",
-				"floppy/windows-2012-standard-amd64/configure-winrm.ps1"
+				"floppy/windows-2012-standard-amd64/configure-winrm.ps1",
+				"floppy/common/install-cygwin-sshd.sh"
 			]
 		}
 	],
 	"provisioners": [
-		{
-			"type": "file",
-			"source": "floppy/common/install-cygwin-sshd.sh",
-			"destination": "C:\\install-cygwin-sshd.sh"
-		},
 		{
 			"type": "powershell",
 			"scripts": [


### PR DESCRIPTION
We experienced random build issue due to so unexpected WinRM error when copying Cygwin installation script
This script is not copied during build and we expect it to be more stable now
