### PR TITLE
Avoid a possible clash if building Windows multiple time on the same computer

### DIFF
--- a/windows/build-windows.sh
+++ b/windows/build-windows.sh
@@ -78,7 +78,7 @@ Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Command "shutdown.exe /s
 EOF
 
 echo "$(date "${DATE_FMT}") Retrieving Active Directory certificates…"
-sshpass -p "${WINDOWS_PASSWORD}" scp -P ${SSH_PORT} -o StrictHostKeyChecking=no Administrator@localhost:/cygdrive/c/users/administrator/ad2012.cer "${CURRENT_DIR}"
+sshpass -p "${WINDOWS_PASSWORD}" scp -P ${SSH_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null Administrator@localhost:/cygdrive/c/users/administrator/ad2012.cer "${CURRENT_DIR}"
 
 echo "$(date "${DATE_FMT}") Waiting for windows to shutdown…"
 sleep 20


### PR DESCRIPTION
Windows build relies on SSH to perform copy. The ssh call did considered the knownhost which may cause clashes
