### PR TITLE
Do not remove Nanocloud directory on container cleanup

### DIFF
--- a/dockerfiles/nanocloud-backend/Dockerfile
+++ b/dockerfiles/nanocloud-backend/Dockerfile
@@ -51,7 +51,7 @@ RUN mv iaas/bin/iaas nanocloud/bin/plugins/running/iaas && \
     mv users/front/website/js/components/users nanocloud/bin/front/js/components/users && \
     mv history/front/website/js/components/history nanocloud/bin/front/js/components/history
 
-RUN rm -rf iaas users ldap history nanocloud apps && apt-get clean
+RUN rm -rf iaas users ldap history apps && apt-get clean
 
 ENV GOPATH="$GOPATH:/opt/build/backend"
 


### PR DESCRIPTION
An attempt was made to clean up container after build. It caused the nanocloud directory to be deleted, leading to a broken Nanocloud installation
