### PR TITLE
build.sh used to abort when invoking with no arguments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 SCRIPT_FULL_PATH=$(readlink -e "${0}")
 CURRENT_DIR=$(dirname "${SCRIPT_FULL_PATH}")
 IAAS_DIR="${CURRENT_DIR}/iaas"
@@ -29,7 +28,6 @@ DATE_FMT="+%Y/%m/%d %H:%M:%S"
 
 
 COMMAND=${1}
-shift
 
 if [ "${COMMAND}" = "windows" ]; then
     NANOCLOUD_SKIP_WINDOWS="false"
@@ -44,7 +42,6 @@ elif [ "${COMMAND}" = "nanocloud" ]; then
     NANOCLOUD_SKIP_COREOS="true"
     NANOCLOUD_SKIP="false"
 fi
-
 
 WINDOWS_QCOW2_FILENAME="${CURRENT_DIR}/windows/output-windows-2012R2-qemu/windows-server-2012R2-amd64.qcow2"
 if [ -f "${WINDOWS_QCOW2_FILENAME}" -o "${NANOCLOUD_SKIP_WINDOWS}" = "true" ]; then


### PR DESCRIPTION
Shift command seems to return a non zero error code when there is no argument. This caused the script to exit due to the bash -e option when the script was invoked without any arguments
