### PR TITLE
Delete broken build status icon from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nanocloud community
 
-[![Build Status](https://bamboo.nanocloud.com/plugins/servlet/wittified/build-status/NC-COL)](https://bamboo.nanocloud.com/browse/NC-COL) Current version: **0.1**
+Current version: **0.1**
 
 Experience the seamless transformation of your application.
 


### PR DESCRIPTION
Due to bamboo URL change, build status icon is currently unavailable. Thus is has been deleted from the README.
