### PR TITLE
The installer do not abort on first error

### DIFF
--- a/nanocloud.sh
+++ b/nanocloud.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Nanocloud Community, a comprehensive platform to turn any application
 # into a cloud solution.


### PR DESCRIPTION
The installer should abort when an error occured. This patch has been tested on ideal conditions and all the script went through
