### PR TITLE
Force containers to restart on failure

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -7,8 +7,10 @@ guacamole-client:
  volumes:
   - ./guacamole-client/guac_home/guacamole.properties:/etc/guacamole/guacamole.properties
   - ./guacamole-client/guac_home/noauth-config.xml:/etc/guacamole/noauth-config.xml
+ restart: always
 guacamole-server:
  image: glyptodon/guacd
+ restart: always
 nanocloud-backend:
  build: ./
  dockerfile: Dockerfile-nanocloud
@@ -28,6 +30,7 @@ nanocloud-backend:
   - ./guacamole-client/guac_home/noauth-config.xml:/opt/conf/noauth.xml
  volumes_from:
   - guacamole-client
+ restart: always
 proxy:
  image: nginx
  volumes:
@@ -39,13 +42,16 @@ proxy:
  ports:
   - 80:80
   - 443:443
+ restart: always
 ambassador:
  image: cpuguy83/docker-grand-ambassador
  volumes:
  - "/var/run/docker.sock:/var/run/docker.sock"
  command: "-name dockerfiles_guacamole-client_1 -name dockerfiles_proxy_1 "
+ restart: always
 rabbitmq:
-  image: rabbitmq
+ image: rabbitmq
+ restart: always
 postgres:
  image: postgres
  volumes:
@@ -53,6 +59,7 @@ postgres:
  environment:
   - PGDATA=/var/lib/postgresql/data/pgdata
   - POSTGRES_USER=nanocloud
+ restart: always
 apps-module:
  dockerfile: Dockerfile-apps
  build: .
@@ -69,6 +76,7 @@ apps-module:
   - XML_CONFIGURATION_FILE=/opt/conf/noauth.xml
   - WINDOWS_DOMAIN=intra.localdomain.com
   - EXECUTION_SERVERS=10.0.2.2
+ restart: always
 history-module:
  dockerfile: Dockerfile-history
  build: .
@@ -79,6 +87,7 @@ history-module:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
   - DATABASE_URI=postgres://nanocloud@postgres/nanocloud?sslmode=disable
+ restart: always
 iaas-module:
  dockerfile: Dockerfile-iaas
  build: .
@@ -89,6 +98,7 @@ iaas-module:
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
   - API_URL=http://10.0.2.2
   - API_PORT=8082
+ restart: always
 ldap-module:
  dockerfile: Dockerfile-ldap
  build: .
@@ -100,6 +110,7 @@ ldap-module:
   - USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com
   - PASSWORD=Nanocloud123+
   - SERVER_URL=ldaps://10.0.2.2:6360
+ restart: always
 users-module:
  dockerfile: Dockerfile-users
  build: .
@@ -110,3 +121,4 @@ users-module:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
   - DATABASE_URI=postgres://nanocloud@postgres/nanocloud?sslmode=disable
+ restart: always

--- a/dockerfiles/nanocloud.service
+++ b/dockerfiles/nanocloud.service
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 TimeoutStartSec=0
-ExecStart=/home/core/dockerfiles/docker-compose -f /home/core/dockerfiles/docker-compose.yml up
+ExecStart=/home/core/dockerfiles/docker-compose -f /home/core/dockerfiles/docker-compose.yml up -d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Containers now automatically restart on failure.
nanocloud.service has been modified so docker-compose up is running with the daemon option to allow containers to properly reboot on startup in case there is a race condition
