### PR TITLE
Remove unnecessary volume mapping in dockerfile

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -29,8 +29,6 @@ nanocloud-backend:
   - postgres:postgres
   - rabbitmq:rabbitmq
  volumes:
-  - ./conf/ldaprc:/etc/ldap/ldap.conf:ro
-  - ./conf/ad2012.cer:/opt/conf/ad2012.cer:ro
   - ./guacamole-client/guac_home/noauth-config.xml:/opt/conf/noauth.xml
  volumes_from:
   - guacamole-client


### PR DESCRIPTION
ldaprc and ad2012,cer are now handle by module-ldap instead of nanocloud-backend. Thus such mapping became useless
