### PR TITLE
Make containers to share the same network

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -1,17 +1,16 @@
 guacamole-client:
  build: ./
  dockerfile: guacamole-client/Dockerfile
- links:
-  - guacamole-server:guacd
-  - ambassador:proxy
  volumes:
   - ./guacamole-client/guac_home/guacamole.properties:/etc/guacamole/guacamole.properties
   - ./guacamole-client/guac_home/noauth-config.xml:/etc/guacamole/noauth-config.xml
  restart: always
+ container_name: "guacamole-client"
 
 guacamole-server:
  image: glyptodon/guacd:0.9.8
  restart: always
+ container_name: "guacamole-server"
 
 nanocloud-backend:
  build: ./
@@ -26,28 +25,23 @@ nanocloud-backend:
   - WIN_PORT=1119
   - WIN_USER=Administrator
   - WIN_SERVER=10.0.2.2
- links:
-  - guacamole-client:guacamole
-  - postgres:postgres
-  - rabbitmq:rabbitmq
  volumes:
   - ./guacamole-client/guac_home/noauth-config.xml:/opt/conf/noauth.xml
  volumes_from:
   - guacamole-client
  restart: always
+ container_name: "nanocloud-api"
 
 proxy:
  image: nginx:1.9
  volumes:
   - ./nginx/conf/nginx.conf:/etc/nginx/conf.d/default.conf:ro
   - ./nginx/conf/certificates:/etc/nginx/ssl/:ro
- links:
-  - nanocloud-backend:nanocloud-api
-  - ambassador:guacamole-client
  ports:
   - 80:80
   - 443:443
  restart: always
+ container_name: "proxy"
 
 ambassador:
  image: cpuguy83/docker-grand-ambassador:0.9.1
@@ -55,10 +49,12 @@ ambassador:
  - "/var/run/docker.sock:/var/run/docker.sock"
  command: "-name dockerfiles_guacamole-client_1 -name dockerfiles_proxy_1 "
  restart: always
+ container_name: "ambassador"
 
 rabbitmq:
  image: rabbitmq:3.5
  restart: always
+ container_name: "rabbitmq"
 
 postgres:
  image: postgres:9.4
@@ -68,12 +64,11 @@ postgres:
   - PGDATA=/var/lib/postgresql/data/pgdata
   - POSTGRES_USER=nanocloud
  restart: always
+ container_name: "postgres"
 
 apps-module:
  dockerfile: Dockerfile-apps
  build: .
- links:
-  - rabbitmq:rabbitmq
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
@@ -88,31 +83,28 @@ apps-module:
  restart: always
  volumes:
   - ./guacamole-client/guac_home/noauth-config.xml:/opt/conf/noauth.xml
+ container_name: "apps-module"
 
 history-module:
  dockerfile: Dockerfile-history
  build: .
- links:
-  - postgres:postgres
-  - rabbitmq:rabbitmq
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
   - DATABASE_URI=postgres://nanocloud@postgres/nanocloud?sslmode=disable
  restart: always
+ container_name: "history-module"
 
 iaas-module:
  dockerfile: Dockerfile-iaas
  build: .
- links:
-  - rabbitmq:rabbitmq
-  - apiiaas-module:apiiaas
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
-  - API_URL=http://apiiaas
+  - API_URL=http://apiiaas-module
   - API_PORT=8082
  restart: always
+ container_name: "iaas-module"
 
 apiiaas-module:
  dockerfile: Dockerfile-apiiaas
@@ -123,12 +115,11 @@ apiiaas-module:
  volumes:
   - installation_dir:/var/lib/nanocloud/
  restart: always
+ container_name: "apiiaas-module"
 
 ldap-module:
  dockerfile: Dockerfile-ldap
  build: .
- links:
-  - rabbitmq:rabbitmq
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
@@ -136,15 +127,14 @@ ldap-module:
   - PASSWORD=Nanocloud123+
   - SERVER_URL=ldaps://10.20.12.20
  restart: always
+ container_name: "ldap-module"
 
 users-module:
  dockerfile: Dockerfile-users
  build: .
- links:
-  - postgres:postgres
-  - rabbitmq:rabbitmq
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
   - DATABASE_URI=postgres://nanocloud@postgres/nanocloud?sslmode=disable
  restart: always
+ container_name: "users-module"


### PR DESCRIPTION
Containers now share the same private network instead of using docker's old link behavior.
This requires to run docker-compose with : docker-compose --x-networking up -d
