### PR TITLE
Install qemu inside apiiaas-module's container

### DIFF
--- a/dockerfiles/apiiaas/Dockerfile
+++ b/dockerfiles/apiiaas/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER \
   William Riancho <william.riancho@nanocloud.com>
 
 RUN apt-get update && \
-    apt-get -y install git
+    apt-get -y install git qemu-system-x86
 
 RUN go get "github.com/gorilla/rpc" && \
     go get "github.com/gorilla/rpc/json" && \

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -22,7 +22,7 @@ nanocloud-backend:
   - WIN_PASSWORD=Nanocloud123+
   - WIN_PORT=1119
   - WIN_USER=Administrator
-  - WIN_SERVER=10.0.2.2
+  - WIN_SERVER=apiiaas-module
  restart: always
  container_name: "nanocloud-api"
 
@@ -104,8 +104,10 @@ apiiaas-module:
   - API_PORT=8082
  volumes:
   - ../installation_dir:/var/lib/nanocloud/
+  - /dev/kvm:/dev/kvm
  restart: always
  container_name: "apiiaas-module"
+ privileged: true
 
 ldap-module:
  build: ./ldap


### PR DESCRIPTION
Now apiiaas is built-in a container it can no longer use host's qemu anymore. This commit adds qemu inside this container.
