### PR TITLE
guacamole.properties expected to find guacd with the wrong hostname

### DIFF
--- a/dockerfiles/guacamole-client/guac_home/guacamole.properties
+++ b/dockerfiles/guacamole-client/guac_home/guacamole.properties
@@ -1,4 +1,4 @@
-guacd-hostname: guacd
+guacd-hostname: guacamole-server
 guacd-port:     4822
 
 # Auth provider class


### PR DESCRIPTION
guacd is served in a container called guacamole-server, still guacamole.properties inside guacamole-client expected to find it in guacd
