### PR TITLE
Remove qemu as a dependency to run nanocloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ For your host computer
 
 You also need to install the following packages on your distribution:
 
-* *qemu-system-x86_64*
 * *curl* or *wget*
 * *netcat*
 

--- a/nanocloud.sh
+++ b/nanocloud.sh
@@ -51,10 +51,6 @@ if [ -z "$(which docker-compose)" ]; then
   echo "$(date "${DATE_FMT}") Docker-compose is missing, please install *docker-compose*"
   exit 2
 fi
-if [ -z "$(which qemu-system-x86_64)" ]; then
-  echo "$(date "${DATE_FMT}") Qemu is missing, please install *qemu-system-x86_64*"
-  exit 2
-fi
 if [ -z "$(which curl)" -o -z "$(which wget)" ]; then
   echo "$(date "${DATE_FMT}") No download method found, please install *curl* or *wget*"
   exit 2


### PR DESCRIPTION
Now qemu is built-in a container (iaasAPI), it is not expected as a dependency to run the software
