### PR TITLE
Disable NLA options in windows

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/Disable-NLA.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/Disable-NLA.ps1
@@ -1,0 +1,2 @@
+# Poweshell script to disable NLA option for our collection
+Set-RDSessionCollectionConfiguration -CollectionName collection -AuthenticateUsingNLA 0

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -90,6 +90,7 @@
 			"type": "powershell",
 			"scripts": [
 				"floppy/windows-2012-standard-amd64/AD-create-OU.ps1",
+				"floppy/windows-2012-standard-amd64/Disable-NLA.ps1",
 				"floppy/windows-2012-standard-amd64/adcs-cert.ps1"
 			],
 			"pause_before": "120s"


### PR DESCRIPTION
Disable Network Level Authentication for remote applications in Nanocloud collection.
