### PR TITLE
Use the apiiaas domain name in ldap configuration

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -114,8 +114,8 @@ ldap-module:
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
-  - SSH_SERVER_URI=Administrator:Nanocloud123+@172.17.0.1:6001
-  - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@172.17.0.1:6003
+  - SSH_SERVER_URI=Administrator:Nanocloud123+@apiiaas-module:6001
+  - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@apiiaas-module:6003
   - BASE=DC=intra,DC=localdomain,DC=com
   - LDAP_USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com
   - BIND_DN=CN=Administrator,DC=intra,DC=localdomain,DC=com


### PR DESCRIPTION
Instead of using Docker's unreliable IP address, use apiiaas's domain name in environment configuration
