### PR TITLE
Update guacamole.properties so histories are recorded using new API

### DIFF
--- a/dockerfiles/guacamole-client/guac_home/guacamole.properties
+++ b/dockerfiles/guacamole-client/guac_home/guacamole.properties
@@ -4,8 +4,8 @@ guacd-port:     4822
 # Auth provider class
 noauth-config: /etc/guacamole/noauth-config.xml
 
-noauthlogged-server-url: localhost
-noauthlogged-server-port: 8081
-noauthlogged-server-endpoint: rpc
+noauthlogged-server-url: nanocloud-api
+noauthlogged-server-port: 8080
+noauthlogged-server-endpoint: api/history
 noauthlogged-server-username: admin@nanocloud.com
 noauthlogged-server-password: admin


### PR DESCRIPTION
This noauth-logged pull request also need to be reviewed https://github.com/Nanocloud/noauth-logged/pull/2
