### PR TITLE
adjust apps config values

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -114,8 +114,8 @@ ldap-module:
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
-  - SSH_SERVER_URI=ssh://Administrator:Nanocloud123+@172.17.0.1:6001
-  - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@172.17.0.1:6003
+  - SSH_SERVER_URI=ssh://Administrator:Nanocloud123+@apiiaas-module:1119
+  - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@apiiaas-module:6360
   - BASE=DC=intra,DC=localdomain,DC=com
   - LDAP_USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com
   - BIND_DN=CN=Administrator,DC=intra,DC=localdomain,DC=com


### PR DESCRIPTION
ldap now automatically uses apiiaas domain name and ssh port instead of hardcoded values
