### PR TITLE
Install missing sshpass in apps-module

### DIFF
--- a/dockerfiles/apps/Dockerfile
+++ b/dockerfiles/apps/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.5.1
 MAINTAINER \
   William Riancho <william.riancho@nanocloud.com>
 
+RUN apt-get update && apt-get install sshpass
+
 RUN go get -u github.com/constabulary/gb/...
 RUN mkdir -p /build/
 


### PR DESCRIPTION
Pull request #9 (https://github.com/Nanocloud/apps/pull/9) on apps-module introduced a dependency to sshpass since it know uses it to communicate with the Windows droping the old exec.sh legacy behavior
