### PR TITLE
Ajust Windows qcow2 path to 0.2 release

### DIFF
--- a/iaasAPI/main.go
+++ b/iaasAPI/main.go
@@ -69,7 +69,7 @@ func WriteConf(in interface{}, filename string) error {
 func getDefaultConf() Configuration {
 	return Configuration{
 		InstallationDir: "/var/lib/nanocloud",
-		ArtifactURL:     "http://releases.nanocloud.org:8080/indiana/",
+		ArtifactURL:     "http://releases.nanocloud.org:8080/releases/0.2/",
 	}
 }
 


### PR DESCRIPTION
ArtifactURL used to redirect to indiana. It needs to be stabilized to 0.2
