### PR TITLE
Fix nginx https redirection

### DIFF
--- a/dockerfiles/nginx/conf/nginx.conf
+++ b/dockerfiles/nginx/conf/nginx.conf
@@ -9,7 +9,7 @@ server {
     server_name localhost;
 
     ## redirect http to https ##
-    rewrite ^ https://\$server_name\$request_uri? permanent;
+    rewrite ^ https://$host$request_uri? permanent;
 }
 
 # HTTPS server


### PR DESCRIPTION
Nginx redirects any http request to `https://\localhost\/[...]`.
This fix now redirect to `https://[original host]/[...]`
