### PR TITLE
Prevent postgres from creating a root owned directory impossible to delete

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -52,8 +52,6 @@ rabbitmq:
 
 postgres:
  image: postgres:9.4
- volumes:
-  - ./postgres:/var/lib/postgresql/data/pgdata
  environment:
   - PGDATA=/var/lib/postgresql/data/pgdata
   - POSTGRES_USER=nanocloud


### PR DESCRIPTION
The volume between postgres and the host was created in order to persist data. Turns out now we use docker-compose we can easily restart previously stopped containers and thus keep the data.
So, unless we run the uninstaller, postgres' data will persist by design.
