### PR TITLE
Adapt readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ You also need to install the following packages on your distribution:
 * *docker*
 * *docker-compose*
 * *curl* or *wget*
-* *netcat*
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For your host computer
 You also need to install the following packages on your distribution:
 
 * *docker*
+* *docker-compose*
 * *curl* or *wget*
 * *netcat*
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Building Windows from Nanocloud Community requires some packages :
 Then to build your own installer, use this script:
 
 ```
+./build.sh windows
+./build.sh nanocloud
+```
+
+Or simply to build both in one command :
+
+```
 ./build.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ You also need to install the following packages on your distribution:
 * *docker-compose*
 * *curl* or *wget*
 
+## Uninstall
+
+To uninstall Nanocloud, run the script nanocloud_uninstall.sh located in the root of the install directory
+
+````
+./nanocloud_uninstall.sh
+````
+
+Then you will need to manually remove your current directory
+
 ## How to build
 
 Building Windows from Nanocloud Community requires some packages :

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nanocloud community
 
-Current version: **0.1**
+Current version: **0.2**
 
 Experience the seamless transformation of your application.
 
@@ -12,53 +12,43 @@ applications with new uses.
 
 ## Quickinstall
 
-Simply run the following command as **root** to install and run **Nanocloud**:
+Simply run the following command to install and run **Nanocloud**:
 
 ```
-curl --progress-bar "http://community.nanocloud.com/nanocloud.sh" | sh
+curl --progress-bar "http://community.nanocloud.com/one-liner.sh" | sh
 ```
 
-> Note: You need to be *root* on the host machine to run **Nanocloud**. This
-> won't be necessary any more in the next release.
-
-At the end of the installation Nanocloud community will be installed in
-*/var/lib/nanocloud*.
+> Read carefully outputs for this script, it will prodive you usefull
+> information about the installation directory and URL where your installation
+> will be accessible.
 
 ### Alternative to curl
 
-If you don't want to or cannot use *curl*, you can launch the **one-liner** this way:
+If you don't want to or cannot use *curl*, you can launch the **one-liner** this
+way:
 
 ```
-wget "http://community.nanocloud.com/nanocloud.sh" -q -O - | sh
+wget "http://community.nanocloud.com/one-liner.sh" -q -O - | sh
 ```
 
 ## Prerequisites
 
 For your host computer
 
-* You must be able to login as root.
 * CPU must support hardware virtualization (Intel VT-x or AMD-V).
 * Operating system must be a linux 64 bit. It is advised to use Debian 8 or
   later. Other Linux distributions may work.
-* At least 4GB of RAM available (6GB recommended).
-* At least 6GB disk space (10GB recommended, depending on the software you want to
-  deploy).
+* At least 4GB of RAM available.
+* At least 7GB disk space (10GB recommended, depending on the software you want
+  to deploy).
 
 You also need to install the following packages on your distribution:
 
+* *docker*
 * *curl* or *wget*
 * *netcat*
 
 ## How to build
-
-You will need some tools to build Nanocloud
-
-* gcc
-* git
-* go
-* packer
-* qemu-system-x86_64
-* ssh_pass
 
 Then to build your own installer, use this script:
 
@@ -66,14 +56,13 @@ Then to build your own installer, use this script:
 ./build.sh
 ```
 
-It will build windows image, coreos image and then nanocloud tools. You can
-launch the following command to install your build on your system:
+It will build windows image and then nanocloud containers.
+Afterwards, You can launch the following command to install your build on your
+system:
 
 ```
 ./nanocloud.sh
 ```
-
-> Note: for now, you have to be *root* to execute the lase command. This will change in next release
 
 ## Known bugs
 
@@ -83,23 +72,16 @@ will be fixed in future releases.
 If your issue isn't listed bellow, please report it
 [here](https://github.com/Nanocloud/community/issues/new)
 
-* This installation won't work with **parallels** or **virtualbox**.
 * While downloading **Windows**, information disappears from home page.
-* CoreOS qcow2 disk keeps growing until it's full and cause some 
-[issue](http://stackoverflow.com/questions/31712266/how-to-clean-up-docker-overlay-directory).
-* When CoreOS VM is stopped, users are erased.
-* When an application is published, a connection for admin user is displayed but will not work.
 
 ## Roadmap
 
 In future releases, we plan to add :
 
-* Installation as a non-root user.
 * Customize applications names and icons.
 * Assign permission per application and per users.
 * Dashboard to get information on the hosting platform.
 * Buttons to log off a user from its windows session.
-* A better authentication method.
 * Display live metrics graphs (RAM/DISK/CPU usage).
 * Change users information (not just password).
 * Show last connection per user.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ You also need to install the following packages on your distribution:
 
 ## How to build
 
+Building Windows from Nanocloud Community requires some packages :
+
+* *packer*
+* *qemu*
+* *sshpass*
+* *netcat*
+
 Then to build your own installer, use this script:
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ applications with new uses.
 Simply run the following command to install and run **Nanocloud**:
 
 ```
-curl --progress-bar "http://community.nanocloud.com/installer.sh" | sh
+curl --progress-bar "http://releases.nanocloud.org:8080/releases/latest/installer.sh" | sh
 ```
 
 > Read carefully outputs for this script, it will prodive you usefull
@@ -28,7 +28,7 @@ If you don't want to or cannot use *curl*, you can launch the **installer** this
 way:
 
 ```
-wget "http://community.nanocloud.com/installer.sh" -q -O - | sh
+wget "http://releases.nanocloud.org:8080/releases/latest/installer.sh" -q -O - | sh
 ```
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ applications with new uses.
 Simply run the following command to install and run **Nanocloud**:
 
 ```
-curl --progress-bar "http://community.nanocloud.com/one-liner.sh" | sh
+curl --progress-bar "http://community.nanocloud.com/installer.sh" | sh
 ```
 
 > Read carefully outputs for this script, it will prodive you usefull
@@ -24,11 +24,11 @@ curl --progress-bar "http://community.nanocloud.com/one-liner.sh" | sh
 
 ### Alternative to curl
 
-If you don't want to or cannot use *curl*, you can launch the **one-liner** this
+If you don't want to or cannot use *curl*, you can launch the **installer** this
 way:
 
 ```
-wget "http://community.nanocloud.com/one-liner.sh" -q -O - | sh
+wget "http://community.nanocloud.com/installer.sh" -q -O - | sh
 ```
 
 ## Prerequisites


### PR DESCRIPTION
Push version to v0.2
Reference docker-compose as a dependency in the README
Netcat as been removed in favor of curl to test connectivity
List dependencies to build Windows
