### PR TITLE
Install one-liner now explicitly install nanocloud in the current directory

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -39,4 +39,4 @@ if [ -z "$(which docker-compose)" ]; then
 fi
 
 docker run -e HOST_UID=$SCRIPT_UID -v ${PWD}/nanocloud:/var/lib/nanocloud nanocloud/community:${COMMUNITY_TAG}
-$CURRENT_DIR/nanocloud/installation_dir/scripts/start.sh ${COMMUNITY_TAG}
+${PWD}/nanocloud/installation_dir/scripts/start.sh ${COMMUNITY_TAG}


### PR DESCRIPTION
Previously current working directory was deduced from a readlink and not explicitly set to the PWD
