### PR TITLE
Add a workaround to ignore some error in bash script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ if [ -f "${NANOCLOUD_OUTPUT}" -o "${NANOCLOUD_SKIP}" = "true" ]; then
     echo "$(date "${DATE_FMT}") Skip Nanocloud build"
 else
     echo "# Building Nanocloud"
-    DOCKER_COMPOSE=$(which docker-compose)
+    DOCKER_COMPOSE=$(which docker-compose || true)
     if [ -z "${DOCKER_COMPOSE}" ]; then
         echo "You need *docker-compose* to run this script, exiting"
         exit 1

--- a/installation_dir/scripts/launch-windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64.sh
+++ b/installation_dir/scripts/launch-windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64.sh
@@ -31,7 +31,11 @@ SSH_PORT=1119
 RDP_PORT=3389
 LDAPS_PORT=6360
 
-QEMU=$(which qemu-system-x86_64)
+QEMU=$(which qemu-system-x86_64 || true)
+if [ -z "${QEMU}" ]; then
+    echo "You need *QEMU* to run this script, exiting"
+    exit 1
+fi
 SYSTEM_VHD="${NANOCLOUD_DIR}/images/${VM_NAME}.qcow2"
 VM_NCPUS="$(grep -c ^processor /proc/cpuinfo)"
 

--- a/installation_dir/scripts/start.sh
+++ b/installation_dir/scripts/start.sh
@@ -73,15 +73,15 @@ NANOCLOUD_STATUS=""
 echo "$(date "${DATE_FMT}") Testing connectivity"
 for run in $(seq 60) ; do
     if [ "${NANOCLOUD_STATUS}" != "200" ]; then
-	CURL_CMD=$(which curl)
-	WGET_CMD=$(which wget)
-	if [ -n "${CURL_CMD}" ]; then
+        CURL_CMD=$(which curl)
+        WGET_CMD=$(which wget)
+        if [ -n "${CURL_CMD}" ]; then
             NANOCLOUD_STATUS=$(curl --output /dev/null --insecure --silent --write-out '%{http_code}\n' "https://localhost")
-	elif [ -n "${WGET_CMD}" ]; then
+        elif [ -n "${WGET_CMD}" ]; then
             NANOCLOUD_STATUS=$(LANG=C wget --no-check-certificate "https://localhost" -O /dev/null 2>&1 | awk '/^HTTP/ { print $6 ;}')
-	fi
+        fi
     else
-	break ;
+        break ;
     fi
     sleep 1
 done

--- a/installation_dir/scripts/stop.sh
+++ b/installation_dir/scripts/stop.sh
@@ -34,11 +34,11 @@ COMMAND=${1}
 
 COMMUNITY_CHANNEL=$(cat ${CHANNEL_FILE})
 
-if [ -z "$(which docker)" ]; then
+if [ -z "$(which docker || true)" ]; then
   echo "$(date "${DATE_FMT}") Docker is missing, please install *docker*"
   exit 2
 fi
-if [ -z "$(which docker-compose)" ]; then
+if [ -z "$(which docker-compose || true)" ]; then
   echo "$(date "${DATE_FMT}") Docker-compose is missing, please install *docker-compose*"
   exit 2
 fi

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -29,11 +29,11 @@ if [ "${COMMAND}" = "indiana" ]; then
     COMMUNITY_TAG="indiana"
 fi
 
-if [ -z "$(which docker)" ]; then
+if [ -z "$(which docker || true)" ]; then
   echo "$(date "${DATE_FMT}") Docker is missing, please install *docker*"
   exit 2
 fi
-if [ -z "$(which docker-compose)" ]; then
+if [ -z "$(which docker-compose || true)" ]; then
   echo "$(date "${DATE_FMT}") Docker-compose is missing, please install *docker-compose*"
   exit 2
 fi

--- a/windows/build-windows.sh
+++ b/windows/build-windows.sh
@@ -30,21 +30,21 @@ WINDOWS_PASSWORD="Nanocloud123+"
 VM_HOSTNAME="windows-2012R2"
 VM_NCPUS="$(grep -c ^processor /proc/cpuinfo)"
 SSH_PORT=1119
-QEMU=$(which qemu-system-x86_64)
+QEMU=$(which qemu-system-x86_64 || true)
 
-if [ -z "$(which packer)" ]; then
+if [ -z "$(which packer || true)" ]; then
   echo "$(date "${DATE_FMT}") Packer is missing, please install *packer*"
   exit 2
 fi
-if [ -z "$(which qemu-system-x86_64)" ]; then
+if [ -z "${QEMU}" ]; then
   echo "$(date "${DATE_FMT}") Qemu is missing, please install *qemu*"
   exit 2
 fi
-if [ -z "$(which sshpass)" ]; then
+if [ -z "$(which sshpass || true)" ]; then
   echo "$(date "${DATE_FMT}") sshpass is missing, please install *sshpass*"
   exit 2
 fi
-if [ -z "$(which netcat)" ]; then
+if [ -z "$(which netcat || true)" ]; then
   echo "$(date "${DATE_FMT}") netcat is missing, please install *netcat*"
   exit 2
 fi


### PR DESCRIPTION
When option « -e » is set in bash, checks for dependency exit the script as they state an error.

This workarround avoid sending error to the main environment and continue script with error display.
