### PR TITLE
HOTFIX: Fix installation_dir location compose to docker-compose file

### DIFF
--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -101,7 +101,7 @@ apiiaas-module:
   - NANOCLOUD_DIR=/var/lib/nanocloud
   - API_PORT=8082
  volumes:
-  - ./installation_dir:/var/lib/nanocloud/
+  - ../installation_dir:/var/lib/nanocloud/
   - /dev/kvm:/dev/kvm
  restart: always
  container_name: "apiiaas-module"


### PR DESCRIPTION
Docker-compose-build.yml has been moved but it still expect the folder installation_dir to be in the same directory
