### PR TITLE
Add missing sshpass in ldap-module

### DIFF
--- a/modules/ldap/Dockerfile
+++ b/modules/ldap/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER \
   Olivier Berthonneau <olivier.berthonneau@nanocloud.com> \
 
 
+RUN apt-get update && apt-get install libldap2-dev sshpass
 RUN mkdir -p /go/build/ldap
 
 COPY ./ /go/build/ldap


### PR DESCRIPTION
When rewriting Dockerfile so it's compliant with the new repo architecture. SSHpass was missed to be added to the repository
