### PR TITLE
Fix root docker-compose files to use modules's docker-compose file new location

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -1,66 +1,66 @@
 guacamole-client:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-client
  image: nanocloud/guacamole-client:indiana
 
 guacamole-server:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-server
 
 nanocloud-backend:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-backend:indiana
 
 proxy:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: proxy
 
 ambassador:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: ambassador
 
 rabbitmq:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: rabbitmq
 
 postgres:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: postgres
 
 apps-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: apps-module
  image: nanocloud/apps-module:indiana
 
 history-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: history-module
  image: nanocloud/history-module:indiana
 
 iaas-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: iaas-module
  image: nanocloud/iaas-module:indiana
 
 ldap-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: ldap-module
  image: nanocloud/ldap-module:indiana
 
 users-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: users-module
  image: nanocloud/users-module:indiana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,66 +1,66 @@
 guacamole-client:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-client
  image: nanocloud/guacamole-client:0.2
 
 guacamole-server:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-server
 
 nanocloud-backend:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-backend:0.2
 
 proxy:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: proxy
 
 ambassador:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: ambassador
 
 rabbitmq:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: rabbitmq
 
 postgres:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: postgres
 
 apps-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: apps-module
  image: nanocloud/apps-module:0.2
 
 history-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: history-module
  image: nanocloud/history-module:0.2
 
 iaas-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: iaas-module
  image: nanocloud/iaas-module:0.2
 
 ldap-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: ldap-module
  image: nanocloud/ldap-module:0.2
 
 users-module:
  extends:
-  file: ./dockerfiles/docker-compose.yml
+  file: ./modules/docker-compose.yml
   service: users-module
  image: nanocloud/users-module:0.2


### PR DESCRIPTION
Root located docker-compose file still expected to extends a docker-compose.yml in the dockerfiles directory
