### PR TITLE
Allow frontend container to boot in both indiana and stable channel

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -15,6 +15,12 @@ nanocloud-backend:
   service: nanocloud-backend
  image: nanocloud/nanocloud-backend:indiana
 
+nanocloud-frontend:
+ extends:
+  file: ./modules/docker-compose.yml
+  service: nanocloud-backend
+ image: nanocloud/nanocloud-frontend:indiana
+
 proxy:
  extends:
   file: ./dockerfiles/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ nanocloud-backend:
   service: nanocloud-backend
  image: nanocloud/nanocloud-backend:0.2
 
+nanocloud-frontend:
+ extends:
+  file: ./modules/docker-compose.yml
+  service: nanocloud-backend
+ image: nanocloud/nanocloud-frontend:0.2
+
 proxy:
  extends:
   file: ./dockerfiles/docker-compose.yml


### PR DESCRIPTION
Add missing reference to nanocloud-frontend in both docker-compose.yml and docker-compose-indiana.yml in the root directory
