### PR TITLE
Added possibility to add an App from Rest API

### DIFF
--- a/modules/apps/apps.go
+++ b/modules/apps/apps.go
@@ -439,7 +439,7 @@ func publishApp(path string) error {
 			conf.User,
 			conf.Server,
 		),
-		"C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe C:/publishApplication.ps1 "+path,
+		"C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe", "C:/publishApplication.ps1", path,
 	)
 	response, err := cmd.CombinedOutput()
 	if err != nil {

--- a/modules/apps/apps.go
+++ b/modules/apps/apps.go
@@ -430,7 +430,6 @@ func syncUploadedFile(Filename string) {
 }*/
 
 func publishApp(path string) error {
-	module.Log.Error("PATH ==== " + path)
 	cmd := exec.Command(
 		"sshpass", "-p", conf.Password,
 		"ssh", "-o", "StrictHostKeyChecking=no",

--- a/modules/apps/apps.go
+++ b/modules/apps/apps.go
@@ -85,7 +85,6 @@ func getUsers() ([]nano.User, error) {
 	}
 
 	var m []nano.User
-	module.Log.Error(string(res.Body))
 	err = json.Unmarshal(res.Body, &m)
 
 	if err != nil {
@@ -429,3 +428,23 @@ func syncUploadedFile(Filename string) {
 		Log("SCP upload success for file %s\n", Filename)
 	}
 }*/
+
+func publishApp(path string) error {
+	module.Log.Error("PATH ==== " + path)
+	cmd := exec.Command(
+		"sshpass", "-p", conf.Password,
+		"ssh", "-o", "StrictHostKeyChecking=no",
+		"-p", conf.SSHPort,
+		fmt.Sprintf(
+			"%s@%s",
+			conf.User,
+			conf.Server,
+		),
+		"C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe C:/publishApplication.ps1 "+path,
+	)
+	response, err := cmd.CombinedOutput()
+	if err != nil {
+		module.Log.Error("Failed to execute sshpass command to publish an app", err, string(response))
+	}
+	return err
+}

--- a/modules/apps/main.go
+++ b/modules/apps/main.go
@@ -25,7 +25,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -84,7 +83,6 @@ func publishApplication(req nano.Request) (*nano.Response, error) {
 		Path string
 	}
 
-	log.Println(string(req.Body))
 	err := json.Unmarshal(req.Body, &params)
 	if err != nil {
 		module.Log.Error("Umable to unmarshal application path: " + err.Error())

--- a/modules/apps/main.go
+++ b/modules/apps/main.go
@@ -93,7 +93,7 @@ func publishApplication(req nano.Request) (*nano.Response, error) {
 
 	trimmedpath := strings.TrimSpace(params.Path)
 	if trimmedpath == "" {
-		return nano.JSONResponse(500, hash{"error: ": "App path is empty"}), err
+		return nano.JSONResponse(400, hash{"error: ": "App path is empty"}), err
 	}
 	err = publishApp(trimmedpath)
 	if err != nil {

--- a/modules/apps/main.go
+++ b/modules/apps/main.go
@@ -90,7 +90,12 @@ func publishApplication(req nano.Request) (*nano.Response, error) {
 			"error": "path to app must be specified",
 		}), err
 	}
-	err = publishApp(params.Path)
+
+	trimmedpath := strings.TrimSpace(params.Path)
+	if trimmedpath == "" {
+		return nano.JSONResponse(500, hash{"error: ": "App path is empty"}), err
+	}
+	err = publishApp(trimmedpath)
 	if err != nil {
 		return nano.JSONResponse(500, hash{"error: ": err}), err
 	}

--- a/modules/apps/main.go
+++ b/modules/apps/main.go
@@ -92,7 +92,6 @@ func publishApplication(req nano.Request) (*nano.Response, error) {
 			"error": "path to app must be specified",
 		}), err
 	}
-	module.Log.Error("PARAMS ====" + params.Path)
 	err = publishApp(params.Path)
 	if err != nil {
 		return nano.JSONResponse(500, hash{"error: ": err}), err

--- a/windows/floppy/windows-2012-standard-amd64/publishApplication.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/publishApplication.ps1
@@ -15,7 +15,7 @@ Function Get-FileName($initialDirectory)
 Import-Module C:\windows\system32\windowspowershell\v1.0\Modules\RemoteDesktop\RemoteDesktop.psd1
 
 # *** Get our publish app filename ***
-$filename = Get-FileName -initialDirectory "C:\cygwin64\home\Administrator\"
+if ($args[0]) { $filename = $args[0] } else { $filename = Get-FileName -initialDirectory "C:\cygwin64\home\Administrator\" }
 
 # *** Find out the collection name ***
 $apps = Get-RDRemoteApp


### PR DESCRIPTION
New endpoint created ( POST on /api/apps ), allowing to publish a new application which path should be included in the body of the request.
