### PR TITLE
Return a 404 code when disabling a non-existing user

### DIFF
--- a/modules/users/main.go
+++ b/modules/users/main.go
@@ -328,6 +328,13 @@ func disableUser(req nano.Request) (*nano.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if !rows.Next() {
+		rows.Close()
+		return nano.JSONResponse(404, hash{
+			"error": "User not found",
+		}), nil
+	}
 	rows.Close()
 
 	return nano.JSONResponse(200, hash{


### PR DESCRIPTION
When disabling a non existing user the API returned a 200 OK status code. Now it return 404 NOT FOUND
