### PR TITLE
When no apps are published, null isn't returned anymore

### DIFF
--- a/modules/apps/apps.go
+++ b/modules/apps/apps.go
@@ -327,6 +327,9 @@ func listApplications(req nano.Request) (*nano.Response, error) {
 
 		connections = append(connections, connection)
 	}
+	if len(connections) == 0 {
+		connections = []Connection{}
+	}
 	return nano.JSONResponse(200, connections), nil
 }
 


### PR DESCRIPTION
If no apps have been publish yet, the API now returns an empty json structure instead of NULL
