### PR TITLE
Shutdown windows with ssh

### DIFF
--- a/modules/iaas/Dockerfile
+++ b/modules/iaas/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER \
 
 
 RUN apt-get update && \
-    apt-get -y install git qemu-system-x86
+    apt-get -y install git qemu-system-x86 sshpass
 
 RUN mkdir -p /go/build/iaas
 

--- a/modules/iaas/iaas.go
+++ b/modules/iaas/iaas.go
@@ -166,10 +166,24 @@ func Start(name string) error {
 
 func Stop(name string) error {
 
-	var pidFile string = strings.TrimSpace(fmt.Sprintf("%s/pid/%s.pid\n", conf.instDir, name))
-	fmt.Println("stopping : ", name)
-	os.Remove(pidFile)
-	os.Exit(0)
+	module.Log.Error("stopping : ", name)
+
+	cmd := exec.Command(
+		"sshpass", "-p", conf.Password,
+		"ssh", "-o", "StrictHostKeyChecking=no",
+		"-p", conf.SSHPort,
+		fmt.Sprintf(
+			"%s@%s",
+			conf.User,
+			conf.Server,
+		),
+		"C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Command \"Stop-Computer -Force\"",
+	)
+	response, err := cmd.CombinedOutput()
+	if err != nil {
+		module.Log.Error("Failed to execute sshpass command to shutdown windows", err, string(response))
+		return err
+	}
 
 	return nil
 }

--- a/modules/iaas/main.go
+++ b/modules/iaas/main.go
@@ -30,8 +30,12 @@ import (
 var module nano.Module
 
 type Configuration struct {
-	artURL  string
-	instDir string
+	artURL   string
+	instDir  string
+	Server   string
+	User     string
+	SSHPort  string
+	Password string
 }
 
 type VmInfo struct {
@@ -198,8 +202,21 @@ func StopVm(req nano.Request) (*nano.Response, error) {
 	}, nil
 }
 
+func env(key, def string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	return v
+}
+
 func main() {
 	module = nano.RegisterModule("iaas")
+
+	conf.Server = env("SERVER", "62.210.56.45")
+	conf.Password = env("PASSWORD", "ItsPass1942+")
+	conf.User = env("USER", "Administrator")
+	conf.SSHPort = env("SSH_PORT", "22")
 
 	conf.instDir = os.Getenv("INSTALLATION_DIR")
 	if len(conf.instDir) == 0 {
@@ -212,7 +229,7 @@ func main() {
 	}
 
 	module.Get("/iaas", ListRunningVm)
-	module.Post("/iaas/:id", StopVm)
+	module.Post("/iaas/:id/stop", StopVm)
 	module.Post("/iaas/:id/start", StartVm)
 	module.Post("/iaas/:id/download", DownloadVm)
 


### PR DESCRIPTION
Instead of exiting abruptly windows with an os.exit in the iaas-module, the module now contacts windows by ssh and executes a shutdown command in powershell.
