### PR TITLE
Updated log and return error of disable function to match new uuid system

### DIFF
--- a/modules/ldap/main.go
+++ b/modules/ldap/main.go
@@ -506,10 +506,10 @@ func forcedisableAccount(req nano.Request) (*nano.Response, error) {
 	}
 
 	if len(sr.Entries) != 1 {
-		module.Log.Error("Email does not match any user, or several users have the same mail adress")
+		module.Log.Error("Id does not match any user")
 		// means entered mail was not valid, or several user have the same mail
 		return nano.JSONResponse(404, hash{
-			"error": "Email does not match any user, or several users have the same mail adress",
+			"error": "Id does not match any user",
 		}), nil
 	}
 	var cn string


### PR DESCRIPTION
Since uuid are used instead of email addresses to uniquely identify users, the cases of multiple users having the same id is no longer handled. + Changed the word email by Id.
