### PR TITLE
When history database is empty, list doesn't return null anymore

### DIFF
--- a/modules/history/main.go
+++ b/modules/history/main.go
@@ -126,6 +126,10 @@ func ListCall(req nano.Request) (*nano.Response, error) {
 		return nil, err
 	}
 
+	if len(histories) == 0 {
+		histories = []HistoryInfo{}
+	}
+
 	return nano.JSONResponse(200, histories), nil
 }
 


### PR DESCRIPTION
List histories returned null if there were no histories in the database, it now returns an empty json object.
