### PR TITLE
Return an error if a parameter is missing when adding an entry to histories

### DIFF
--- a/modules/history/main.go
+++ b/modules/history/main.go
@@ -143,6 +143,12 @@ func AddCall(req nano.Request) (*nano.Response, error) {
 		}), nil
 	}
 
+	if t.UserId == "" || t.ConnectionId == "" || t.StartDate == "" || t.EndDate == "" {
+		return nano.JSONResponse(400, hash{
+			"error": "Missing parameters",
+		}), nil
+	}
+
 	rows, err := db.Query(
 		`INSERT INTO histories
 		(userid, connectionid, startdate, enddate)


### PR DESCRIPTION
History module, when adding a new history entry, checks if all parameters are present. 
