### PR TITLE
List apps for samaccount doesn't return null anymore if there are no apps

### DIFF
--- a/modules/apps/apps.go
+++ b/modules/apps/apps.go
@@ -384,7 +384,9 @@ func listApplicationsForSamAccount(req nano.Request) (*nano.Response, error) {
 			connections = append(connections, connection)
 		}
 	}
-
+	if len(connections) == 0 {
+		connections = []Connection{}
+	}
 	return nano.JSONResponse(200, connections), nil
 }
 


### PR DESCRIPTION
Now list apps for sam account returns an empty json object instead of null if no apps have been published
