### PR TITLE
Fix history front not loading since frontend isolation

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install && npm run setup
 RUN cd modules/apps && npm install && npm run setup && mv website/js/components/applications ../../website/js/components && mv website/js/components/presenter ../../website/js/components
 RUN cd modules/iaas && npm install && npm run setup && mv website/js/components/services ../../website/js/components
 RUN cd modules/users && npm install && npm run setup && mv website/js/components/users ../../website/js/components
-RUN cd modules/history && npm install && npm run setup && mv website/js/components/history ../../website/js/components
+RUN cd modules/history && npm install && npm run setup && mv website/js/components/history ../../website/js/components && mv website/ts/components/history/views ../../website/js/components/history
 
 EXPOSE 8080
 VOLUME ["/opt/front"]


### PR DESCRIPTION
History-module views were not properly moved and thus were not displayed to the user. Leading the history pages not to be loaded
