### PR TITLE
Fix ldap module impossible to build since sshpass addition

### DIFF
--- a/modules/ldap/Dockerfile
+++ b/modules/ldap/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER \
   Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
 
-RUN apt-get update && apt-get install libldap2-dev sshpass
+RUN apt-get update && apt-get -y install libldap2-dev sshpass
 RUN mkdir -p /go/build/ldap
 
 COPY ./ /go/build/ldap


### PR DESCRIPTION
History-module views were not properly moved and thus were not displayed to the user. Leading the history pages not to be loaded
