### PR TITLE
Fix stop script still referring to old docker-compose file

### DIFF
--- a/installation_dir/scripts/stop.sh
+++ b/installation_dir/scripts/stop.sh
@@ -45,7 +45,7 @@ fi
 
 if [ -f "${DOCKER_COMPOSE_BUILD_OUTPUT}" ]; then
     echo "$(date "${DATE_FMT}") Stopping nanocloud containers from local build"
-    docker-compose --file "${ROOT_DIR}/modules/docker-compose.yml" stop
+    docker-compose --file "${ROOT_DIR}/modules/docker-compose-build.yml" stop
 else
     echo "$(date "${DATE_FMT}") Stopping nanocloud containers from docker hub $COMMUNITY_CHANNEL"
     if [ "${COMMUNITY_CHANNEL}" = "indiana" ]; then


### PR DESCRIPTION
Stop script expects to find a docker-compsoe.yml in modules subdirectory but it has been rename docker-compose-build.yml
