### PR TITLE
Fix uninstall script still referring to old docker-compose file

### DIFF
--- a/nanocloud_uninstall.sh
+++ b/nanocloud_uninstall.sh
@@ -41,7 +41,7 @@ fi
 rm -f ${NANOCLOUD_DIR}/pid/windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64.pid
 
 rm -rf ${CURRENT_DIR}/modules/build_output
-docker-compose -f ${CURRENT_DIR}/modules/docker-compose.yml rm -f > /dev/null 2>&1
+docker-compose -f ${CURRENT_DIR}/modules/docker-compose-build.yml rm -f > /dev/null 2>&1
 docker rmi -f modules_guacamole-client \
        modules_guacamole-server \
        modules_nanocloud-backend \


### PR DESCRIPTION
Uninstall script expects to find a docker-compsoe.yml in modules subdirectory but it has been rename docker-compose-build.yml
