### PR TITLE
Fix root docker-compose files not extending to common docker-compose

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -1,17 +1,17 @@
 guacamole-client:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-client
  image: nanocloud/guacamole-client:indiana
 
 guacamole-server:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-server
 
 nanocloud-backend:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-backend:indiana
  volumes_from:
@@ -19,7 +19,7 @@ nanocloud-backend:
 
 nanocloud-frontend:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-frontend:indiana
  volumes:
@@ -27,45 +27,45 @@ nanocloud-frontend:
 
 proxy:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: proxy
 
 rabbitmq:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: rabbitmq
 
 postgres:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: postgres
 
 apps-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: apps-module
  image: nanocloud/apps-module:indiana
 
 history-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: history-module
  image: nanocloud/history-module:indiana
 
 iaas-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: iaas-module
  image: nanocloud/iaas-module:indiana
 
 ldap-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: ldap-module
  image: nanocloud/ldap-module:indiana
 
 users-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: users-module
  image: nanocloud/users-module:indiana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 guacamole-client:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-client
  image: nanocloud/guacamole-client:0.2
 
 guacamole-server:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: guacamole-server
 
 nanocloud-backend:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-backend:0.2
  volumes_from:
@@ -19,7 +19,7 @@ nanocloud-backend:
 
 nanocloud-frontend:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-frontend:0.2
  volumes:
@@ -27,45 +27,45 @@ nanocloud-frontend:
 
 proxy:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: proxy
 
 rabbitmq:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: rabbitmq
 
 postgres:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: postgres
 
 apps-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: apps-module
  image: nanocloud/apps-module:0.2
 
 history-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: history-module
  image: nanocloud/history-module:0.2
 
 iaas-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: iaas-module
  image: nanocloud/iaas-module:0.2
 
 ldap-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: ldap-module
  image: nanocloud/ldap-module:0.2
 
 users-module:
  extends:
-  file: ./modules/docker-compose-build.yml
+  file: ./modules/docker-compose.yml
   service: users-module
  image: nanocloud/users-module:0.2


### PR DESCRIPTION
Common docker-compose file's name changed from docker-compose-build.yml to docker-compose.yml in modules directory. Name needs to be updated in root docker-compose file as well
