### PR TITLE
Explicit nanocloud-frontend's container name

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -22,6 +22,7 @@ nanocloud-frontend:
   file: ./modules/docker-compose-build.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-frontend:indiana
+ container_name: "nanocloud-frontend"
  volumes:
   - /opt/front
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ nanocloud-frontend:
   file: ./modules/docker-compose-build.yml
   service: nanocloud-backend
  image: nanocloud/nanocloud-frontend:0.2
+ container_name: "nanocloud-frontend"
  volumes:
   - /opt/front
 

--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -21,6 +21,7 @@ nanocloud-frontend:
   service: nanocloud-backend
  volumes:
   - /opt/front
+ container_name: "nanocloud-frontend"
 
 proxy:
  extends:


### PR DESCRIPTION
For some reason there is a name conflict between nanocloud-backend and nanocloud-frontend.
Nanocloud-frontend gets the same container name a nanocloud-backend (nanocloud-api). This is fixed by explicitly set container_name in all docker-compose child files
