### PR TITLE
Fix typo in docker-compose-build.yml leading to invalid build

### DIFF
--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -18,7 +18,7 @@ nanocloud-backend:
 nanocloud-frontend:
  extends:
   file: ./docker-compose.yml
-  service: nanocloud-backend
+  service: nanocloud-frontend
  volumes:
   - /opt/front
 


### PR DESCRIPTION
Manual build could not work since a typo (probably a failed copy past >.<) prevent docker-compose to us the right service
