### PR TITLE
Iaas windows version set in Docker-compose.yml

### DIFF
--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -90,6 +90,7 @@ iaas-module:
   - PASSWORD=Nanocloud123+
   - SERVER=localhost
   - USER=Administrator
+  - ARTIFACT_URL=http://releases.nanocloud.org:8080/releases/0.2/
  volumes:
   - ../installation_dir:/var/lib/nanocloud/
   - /dev/kvm:/dev/kvm

--- a/modules/iaas/main.go
+++ b/modules/iaas/main.go
@@ -219,7 +219,7 @@ func main() {
 
 	conf.artURL = os.Getenv("ARTIFACT_URL")
 	if len(conf.artURL) == 0 {
-		conf.artURL = "http://releases.nanocloud.org:8080/releases/0.2/"
+		conf.artURL = "http://releases.nanocloud.org:8080/releases/latest/"
 	}
 
 	module.Get("/iaas", ListRunningVm)


### PR DESCRIPTION
URL to the Windows qcow2 is set in the Docker-compose file instead of being hardcoded in the go module
Update Windows' URL value to be the latest version possible. Version is set as an environment variable anyway.
