### PR TITLE
when deleting a user, users module now asks ldap to delete it too

### DIFF
--- a/modules/ldap/main.go
+++ b/modules/ldap/main.go
@@ -396,7 +396,6 @@ func createUser(req nano.Request) (*nano.Response, error) {
 		return nil, err
 	}
 
-	// if no disabled accounts were found, a real new user is created
 	res, err := createNewUser(tconf, params, count, ldapConnection)
 	if err != nil {
 		module.Log.Error(err.Error())
@@ -417,7 +416,7 @@ func forcedisableAccount(req nano.Request) (*nano.Response, error) {
 
 	ldapConnection, err := DialandBind()
 	if err != nil {
-		module.Log.Error("Error while connection to Active Directory: " + err.Error())
+		module.Log.Error("Error while connecting to Active Directory: " + err.Error())
 		return nano.JSONResponse(400, hash{
 			"error": err.Error(),
 		}), err
@@ -474,7 +473,7 @@ func deleteUser(req nano.Request) (*nano.Response, error) {
 
 	ldapConnection, err := DialandBind()
 	if err != nil {
-		module.Log.Error("Error while connection to Active Directory: " + err.Error())
+		module.Log.Error("Error while connecting to Active Directory: " + err.Error())
 		return nano.JSONResponse(400, hash{
 			"error": err.Error(),
 		}), err

--- a/modules/users/main.go
+++ b/modules/users/main.go
@@ -380,8 +380,8 @@ func disableUser(req nano.Request) (*nano.Response, error) {
 	}), nil
 }
 
-func disableADUser(id string) error {
-	_, err := module.JSONRequest("POST", "/ldap/users/"+id+"/disable", hash{}, nil)
+func deleteADUser(id string) error {
+	_, err := module.JSONRequest("DELETE", "/ldap/users/"+id, hash{}, nil)
 	return err
 
 }
@@ -416,7 +416,7 @@ func deleteUser(req nano.Request) (*nano.Response, error) {
 		}), nil
 	}
 
-	err = disableADUser(userId)
+	err = deleteADUser(userId)
 	if err != nil {
 		module.Log.Error("Error while deleting user from Active Directory: ", err)
 		return nano.JSONResponse(500, hash{


### PR DESCRIPTION
Users module used to only disable the Active Directory user when deleting him from his database. Now the user is also deleted from the Active Directory.
