### PR TITLE
certificate retreive stage remove for ldap

### DIFF
--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -103,13 +103,11 @@ ldap-module:
  environment:
   - ENV=production
   - AMQP_URI=amqp://guest:guest@rabbitmq:5672/
-  - SSH_SERVER_URI=ssh://Administrator:Nanocloud123+@iaas-module:1119
   - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@iaas-module:6360
   - BASE=DC=intra,DC=localdomain,DC=com
   - LDAP_USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com
   - BIND_DN=CN=Administrator,DC=intra,DC=localdomain,DC=com
   - PASSWORD=
-  - TLS_CACERT=/opt/conf/ad2012.cer
  restart: always
  container_name: "ldap-module"
 

--- a/modules/ldap/Dockerfile
+++ b/modules/ldap/Dockerfile
@@ -3,8 +3,6 @@ MAINTAINER \
   William Riancho <william.riancho@nanocloud.com> \
   Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
-
-RUN apt-get update && apt-get -y install libldap2-dev sshpass
 RUN mkdir -p /go/build/ldap
 
 COPY ./ /go/build/ldap

--- a/windows/build-windows.sh
+++ b/windows/build-windows.sh
@@ -90,9 +90,6 @@ Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Command "sc.exe config R
 Windows/System32/WindowsPowerShell/v1.0/powershell.exe -Command "shutdown.exe /s /f /d p:4:1 /c 'Provisioning Shutdown'"
 EOF
 
-echo "$(date "${DATE_FMT}") Retrieving Active Directory certificates…"
-sshpass -p "${WINDOWS_PASSWORD}" scp -P ${SSH_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null Administrator@localhost:/cygdrive/c/users/administrator/ad2012.cer "${CURRENT_DIR}"
-
 echo "$(date "${DATE_FMT}") Pushing hapticPowershell script to Windows…"
 sshpass -p "${WINDOWS_PASSWORD}" scp -P ${SSH_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${CURRENT_DIR}/floppy/windows-2012-standard-amd64/publishApplication.ps1" Administrator@localhost:/cygdrive/c/publishApplication.ps1
 

--- a/windows/floppy/windows-2012-standard-amd64/adcs-cert.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/adcs-cert.ps1
@@ -3,5 +3,3 @@ Add-WindowsFeature Adcs-Cert-Authority
 $secpasswd = ConvertTo-SecureString "Nanocloud123+" -AsPlainText -Force
 $mycreds = New-Object System.Management.Automation.PSCredential ("Administrator", $secpasswd)
 Install-AdcsCertificationAuthority -CAType "EnterpriseRootCa" -Credential:$mycreds -force:$true
-cmd.exe /c "certutil -ca.cert ad.cer"
-cmd.exe /c "certutil -encode ad.cer ad2012.cer"


### PR DESCRIPTION
The ldap module doesn't need the AD certificate anymore so we don't need to retrieve it from the provisioned windows.
