### PR TITLE
Build Nanocloud when explicitly call ./build nanocloud

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ else
 fi
 
 NANOCLOUD_OUTPUT="${CURRENT_DIR}/modules/build_output"
-if [ -f "${NANOCLOUD_OUTPUT}" -o "${NANOCLOUD_SKIP}" = "true" ]; then
+if [ "${NANOCLOUD_SKIP}" = "true" ]; then
     echo "$(date "${DATE_FMT}") Skip Nanocloud build"
 else
     echo "# Building Nanocloud"


### PR DESCRIPTION
Remove check for build_output file when running build.
Docker-compose already takes care of rebuild re-usage.
