### PR TITLE
Fix CSS issues in the frontend

### DIFF
--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -12,15 +12,15 @@
     "requirejs": "2.x",
     "jquery": "2.x",
     "lodash": "3.x",
-    
+
     "angular": "1.4.x",
     "angular-animate": "1.4.x",
     "angular-aria": "1.4.x",
     "angular-cookies": "1.4.x",
-    
+
     "angular-ui-router": "0.2.x",
     "ui-router-extras": "0.1.x",
-    
+
     "angular-material": "1.x",
     "angular-material-icons": "latest",
     "angular-ui-grid": "3.x",

--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -21,7 +21,7 @@
     "angular-ui-router": "0.2.x",
     "ui-router-extras": "0.1.x",
 
-    "angular-material": "1.x",
+    "angular-material": "1.0.3",
     "angular-material-icons": "latest",
     "angular-ui-grid": "3.x",
     "ng-flow": "2.x"


### PR DESCRIPTION
Bower json specified 1.x for angular-material versions.

Since 1.0.4 broke frontend, this pull request put exact version 1.0.3 in bower.json file
