### PR TITLE
HOTFIX wrong path for docker-compose-dev in stop script

### DIFF
--- a/installation_dir/scripts/stop.sh
+++ b/installation_dir/scripts/stop.sh
@@ -51,7 +51,7 @@ else
     if [ "${COMMUNITY_CHANNEL}" = "indiana" ]; then
 	docker-compose --file "${ROOT_DIR}/docker-compose-indiana.yml" stop
     elif [ "${COMMUNITY_CHANNEL}" = "dev" ]; then
-	docker-compose --file "${ROOT_DIR}/docker-compose-dev.yml" stop
+	docker-compose --file "${ROOT_DIR}/modules/docker-compose-dev.yml" stop
     else
 	docker-compose --file "${ROOT_DIR}/docker-compose.yml" stop
     fi


### PR DESCRIPTION
In case a development environment is detected, stop script did not use the correct docker-compose file leading to an error and no container being stopped
