### PR TITLE
HOTFIX front did not build due to interface misconfiguration

### DIFF
--- a/webapp/website/ts/components/applications/services/ApplicationsSvc.ts
+++ b/webapp/website/ts/components/applications/services/ApplicationsSvc.ts
@@ -25,12 +25,11 @@
 "use strict";
 
 export interface IApplication {
-	Hostname: string;
-	Port: string;
-	Username: string;
-	Password: string;
-	RemoteApp: string;
-	ConnectionName: string;
+	alias: string;
+	collection_name: string;
+	Application: string;
+	display_name: string;
+	file_path: string;
 }
 
 export class ApplicationsSvc {


### PR DESCRIPTION
#199 broke the frontend build. Interface has to be changed to match the API but even if the code was updated to use new values name, the interface still kept the same definition. This led to warning in the dev but those warning were treated as error on compile time.
