### PR TITLE
forbid null string in postgresql

### DIFF
--- a/modules/history/main.go
+++ b/modules/history/main.go
@@ -83,10 +83,10 @@ func setupDb() error {
 
 	rows, err = db.Query(
 		`CREATE TABLE histories (
-			userid		varchar(36),
-			connectionid	varchar(36),
-			startdate	varchar(36),
-			enddate		varchar(36)
+			userid        varchar(36) NOT NULL DEFAULT '',
+			connectionid  varchar(36) NOT NULL DEFAULT '',
+			startdate     varchar(36) NOT NULL DEFAULT '',
+			enddate       varchar(36) NOT NULL DEFAULT ''
 		);`)
 	if err != nil {
 		module.Log.Errorf("Unable to create histories table: %s", err)

--- a/modules/users/lib/users/users.go
+++ b/modules/users/lib/users/users.go
@@ -328,31 +328,19 @@ func (u *Users) GetUser(id string) (*nano.User, error) {
 	if rows.Next() {
 		var user nano.User
 
-		var firstName sql.NullString
-		var lastName sql.NullString
-		var email sql.NullString
-		var sam sql.NullString
-		var windowsPassword sql.NullString
-
 		err = rows.Scan(
 			&user.Id,
-			&firstName,
-			&lastName,
-			&email,
+			&user.FirstName,
+			&user.LastName,
+			&user.Email,
 			&user.IsAdmin,
 			&user.Activated,
-			&sam,
-			&windowsPassword,
+			&user.Sam,
+			&user.WindowsPassword,
 		)
 		if err != nil {
 			return nil, err
 		}
-
-		user.FirstName = firstName.String
-		user.LastName = lastName.String
-		user.Email = email.String
-		user.Sam = sam.String
-		user.WindowsPassword = windowsPassword.String
 
 		return &user, nil
 	}
@@ -376,14 +364,14 @@ func (u *Users) init() error {
 	rows, err = u.db.Query(
 		`CREATE TABLE users (
 				id               varchar(36) PRIMARY KEY,
-				first_name       varchar(36),
-				last_name        varchar(36),
-				email            varchar(36) UNIQUE,
-				password         varchar(60),
+				first_name       varchar(36) NOT NULL DEFAULT '',
+				last_name        varchar(36) NOT NULL DEFAULT '',
+				email            varchar(36) NOT NULL DEFAULT '' UNIQUE,
+				password         varchar(60) NOT NULL DEFAULT '',
 				is_admin         boolean,
 				activated        boolean,
-				sam        	 varchar(35),
-				windows_password varchar(36)
+				sam              varchar(35) NOT NULL DEFAULT '',
+				windows_password varchar(36) NOT NULL DEFAULT ''
 			);`)
 	if err != nil {
 		return err

--- a/nanocloud/db.go
+++ b/nanocloud/db.go
@@ -70,9 +70,9 @@ func setupDb() error {
 		rows, err = db.Query(
 			`CREATE TABLE oauth_clients (
 				id      serial PRIMARY KEY,
-				name    varchar(255) UNIQUE,
-				key     varchar(255) UNIQUE,
-				secret  varchar(255)
+				name    varchar(255) NOT NULL DEFAULT '' UNIQUE,
+				key     varchar(255) NOT NULL DEFAULT '' UNIQUE,
+				secret  varchar(255) NOT NULL DEFAULT ''
 			)`)
 
 		if err != nil {
@@ -113,9 +113,9 @@ func setupDb() error {
 		rows, err = db.Query(
 			`CREATE TABLE oauth_access_tokens (
 				id                serial PRIMARY KEY,
-				token             varchar(255) UNIQUE,
+				token             varchar(255) NOT NULL DEFAULT '' UNIQUE,
 				oauth_client_id   integer REFERENCES oauth_clients (id),
-				user_id           varchar(255)
+				user_id           varchar(255) NOT NULL DEFAULT ''
 			)`)
 
 		if err != nil {


### PR DESCRIPTION
We force Postgres strings to be not null because golang cannot scan a null string to a go String.
