### PR TITLE
HOTFIX fix Angular.js version in bower

### DIFF
--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -13,10 +13,10 @@
     "jquery": "2.x",
     "lodash": "3.x",
 
-    "angular": "1.4.x",
-    "angular-animate": "1.4.x",
-    "angular-aria": "1.4.x",
-    "angular-cookies": "1.4.x",
+    "angular": "1.4.9",
+    "angular-animate": "1.4.9",
+    "angular-aria": "1.4.9",
+    "angular-cookies": "1.4.9",
 
     "angular-ui-router": "0.2.x",
     "ui-router-extras": "0.1.x",
@@ -25,5 +25,8 @@
     "angular-material-icons": "latest",
     "angular-ui-grid": "3.x",
     "ng-flow": "2.x"
-  }
+  },
+    "resolutions": {
+	"angular": "1.4.9"
+    }
 }


### PR DESCRIPTION
Nanocloud build failed because Angular dependencies were not version fixed.
This commit makes sure the tested version of Angular will be used.
