### PR TITLE
Display only installed application in application list

### DIFF
--- a/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
+++ b/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
@@ -71,7 +71,11 @@ export class ApplicationsCtrl {
 
 	loadApplications(): angular.IPromise<void> {
 		return this.applicationsSrv.getAll().then((applications: IApplication[]) => {
-			this.applications = applications;
+			applications.forEach(function(application: IApplication) {
+				if (application.alias !== "" && application.alias !== "hapticPowershell") {
+					this.applications.push(application);
+				}
+			}.bind(this));
 		});
 	}
 


### PR DESCRIPTION
Prevent frontend to display "Desktop" and "hapticPowershell" in application list.
Those are accessible via dedicated buttons anyway.
This also prevent a user from trying to change the name of those apps.
