### PR TITLE
Apps API updated

### DIFF
--- a/nanocloud/main.go
+++ b/nanocloud/main.go
@@ -54,7 +54,7 @@ func main() {
 	 */
 	router.Get("/apps", apps.ListApplications)
 	router.Delete("/apps/:app_id", apps.UnpublishApplication)
-	router.Get("/apps/me", apps.ListApplicationsForSamAccount)
+	router.Get("/apps/me", apps.ListUserApps)
 	router.Post("/apps", apps.PublishApplication)
 	router.Get("/apps/connections", apps.GetConnections)
 	router.Put("/apps/:app_id", middlewares.Admin, apps.ChangeAppName)

--- a/nanocloud/models/apps/apps.go
+++ b/nanocloud/models/apps/apps.go
@@ -149,7 +149,7 @@ func GetAllApps() ([]ApplicationParams, error) {
 
 }
 
-func GetMyApps() ([]ApplicationParams, error) {
+func GetUserApps(userId string) ([]ApplicationParams, error) {
 	var applications []ApplicationParams
 	rows, err := db.Query(
 		`SELECT id, collection_name,
@@ -184,7 +184,6 @@ func GetMyApps() ([]ApplicationParams, error) {
 		applications = []ApplicationParams{}
 	}
 	return applications, nil
-
 }
 
 func CheckPublishedApps() {

--- a/nanocloud/routes/apps/apps.go
+++ b/nanocloud/routes/apps/apps.go
@@ -67,20 +67,18 @@ func ListApplications(req router.Request) (*router.Response, error) {
 }
 
 // ========================================================================================================================
-// Procedure: listApplicationsForSamAccount
+// Procedure: ListUserApps
 //
 // Does:
-// - Return list of applications available for a particular SAM account
+// - Return list of applications available for the current user
 // ========================================================================================================================
-func ListApplicationsForSamAccount(req router.Request) (*router.Response, error) {
-	applications, err := apps.GetMyApps()
+func ListUserApps(req router.Request) (*router.Response, error) {
+	applications, err := apps.GetUserApps(req.User.Id)
 	if err == apps.GetAppsFailed {
 		return router.JSONResponse(500, hash{
 			"error": err.Error(),
 		}), nil
 	}
-
-	//TODO ONLY RETURN AUTHORIZED APPS FROM THE USER'S GROUP
 	return router.JSONResponse(200, applications), nil
 }
 


### PR DESCRIPTION
- `routes.apps.ListApplicationsForSamAccount` renamed `routes.apps.ListUserApps`
- `models.apps.GetMyApps` replaced by `models.apps.GetUserApps`
