### PR TITLE
Test connectivity in environments where docker containers are not local

### DIFF
--- a/installation_dir/scripts/start.sh
+++ b/installation_dir/scripts/start.sh
@@ -82,9 +82,9 @@ for run in $(seq 60) ; do
         CURL_CMD=$(which curl)
         WGET_CMD=$(which wget)
         if [ -n "${CURL_CMD}" ]; then
-            NANOCLOUD_STATUS=$(curl --output /dev/null --insecure --silent --write-out '%{http_code}\n' "https://localhost")
+            NANOCLOUD_STATUS=$(curl --output /dev/null --insecure --silent --write-out '%{http_code}\n' "https://$(docker exec proxy hostname -I | awk '{print $1}')")
         elif [ -n "${WGET_CMD}" ]; then
-            NANOCLOUD_STATUS=$(LANG=C wget --no-check-certificate "https://localhost" -O /dev/null 2>&1 | awk '/^HTTP/ { print $6 ;}')
+            NANOCLOUD_STATUS=$(LANG=C wget --no-check-certificate "https://$(docker exec proxy hostname -I | awk '{print $1}')" -O /dev/null 2>&1 | awk '/^HTTP/ { print $6 ;}')
         fi
     else
         break ;

--- a/installation_dir/scripts/status.sh
+++ b/installation_dir/scripts/status.sh
@@ -31,9 +31,9 @@ NANOCLOUD_DIR=${NANOCLOUD_DIR:-"${ROOT_DIR}/installation_dir"}
 CURL_CMD=$(which curl)
 WGET_CMD=$(which wget)
 if [ -n "${CURL_CMD}" ]; then
-    NANOCLOUD_STATUS=$(curl --output /dev/null --insecure --silent --write-out '%{http_code}\n' "https://localhost")
+    NANOCLOUD_STATUS=$(curl --output /dev/null --insecure --silent --write-out '%{http_code}\n' "https://$(docker exec proxy hostname -I | awk '{print $1}')")
 elif [ -n "${WGET_CMD}" ]; then
-    NANOCLOUD_STATUS=$(LANG=C wget --no-check-certificate "https://localhost" -O /dev/null 2>&1 | awk '/^HTTP/ { print $6 ;}')
+    NANOCLOUD_STATUS=$(LANG=C wget --no-check-certificate "https://$(docker exec proxy hostname -I | awk '{print $1}')" -O /dev/null 2>&1 | awk '/^HTTP/ { print $6 ;}')
 fi
 
 if [ "${NANOCLOUD_STATUS}" != "200" ]; then


### PR DESCRIPTION
Connectivity is tested at the end of start.sh and in status.sh.
It was previously achieved by checking if a HTTPS request to localhost would return a HTTP code 200
In the case docker daemon (and thus the bridge network) are not on the same machine as the docker client (for example in Nanocloud's CI environment) this test always failed.
This fixes the connectivity tests by testing the IP of the proxy container
