### PR TITLE
Remove invalid link to font-awesome.min.css

### DIFF
--- a/webapp/website/index.html
+++ b/webapp/website/index.html
@@ -29,7 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	<link rel="icon" type="image/x-icon" href="favicon.ico?v=2" />
 	<link rel="stylesheet" type="text/css" href="css/libs.min.css" />
 	<link rel="stylesheet" type="text/css" href="css/app.min.css" />
-	<link rel="stylesheet" type="text/css" href="css/font-awesome.min.css" />
 </head>
 <body>
 


### PR DESCRIPTION
font-awesome css is compiled by grunt and doesn't need to be included in the index.
Moreover, it did not work and always returned a 404
