### PR TITLE
Fix presenter logo wrongly adjusting its size

### DIFF
--- a/webapp/website/ts/components/presenter/views/presenter.html
+++ b/webapp/website/ts/components/presenter/views/presenter.html
@@ -3,7 +3,7 @@
 
 	<md-toolbar>
 		<div class="md-toolbar-tools">
-			<img src="./img/logo.png" class="logo" style="width: 8%;"/>
+			<img src="./img/logo.png" class="logo" style="height: 75%;"/>
 			<span flex=""></span>
 			<div class="md-toolbar-item" ng-if="presenterCtrl.user">
 				<md-input-container>


### PR DESCRIPTION
When connected as a user, upper left logo when wrongly adjusted to the window's size due to a bad css property applied to the image.
