### PR TITLE
Remove Disable-NLA from Windows Provisionning

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/Disable-NLA.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/Disable-NLA.ps1
@@ -1,2 +1,0 @@
-# Poweshell script to disable NLA option for our collection
-Set-RDSessionCollectionConfiguration -CollectionName collection -AuthenticateUsingNLA 0

--- a/windows/windows_2012_r2.json
+++ b/windows/windows_2012_r2.json
@@ -90,7 +90,6 @@
 			"type": "powershell",
 			"scripts": [
 				"floppy/windows-2012-standard-amd64/AD-create-OU.ps1",
-				"floppy/windows-2012-standard-amd64/Disable-NLA.ps1",
 				"floppy/windows-2012-standard-amd64/adcs-cert.ps1"
 			],
 			"pause_before": "120s"


### PR DESCRIPTION
This script seems to be useless as it always fails. We can fairly remove it.
