### PR TITLE
Fix #236 : Upload feature needed a refresh to work

### DIFF
--- a/webapp/website/ts/components/applications/haptic.applications.ts
+++ b/webapp/website/ts/components/applications/haptic.applications.ts
@@ -56,8 +56,10 @@ app.config(["$controllerProvider", "$provide", "$futureStateProvider", "flowFact
 	registerCtrlFutureStates(componentName, $futureStateProvider, states);
 
 	flowFactoryProvider.defaults = {
-		headers: {
-			"Authorization": "Bearer " + localStorage["accessToken"]
+		headers: function() {
+			return {
+				"Authorization": "Bearer " + localStorage["accessToken"]
+			}
 		}
 	};
 


### PR DESCRIPTION
Access token was fetched from local storage at application start and wasn't read after login. So the access token used by "flow" library was wrong.
