### PR TITLE
Fix admin cannot open renamed application

### DIFF
--- a/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
+++ b/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
@@ -93,7 +93,7 @@ export class ApplicationsCtrl {
 	}
 
 	openApplication(e: MouseEvent, application: IApplication) {
-		let appToken = btoa(application.Application + "\0c\0noauthlogged");
+		let appToken = btoa(application.alias + "\0c\0noauthlogged");
 		let url = "/guacamole/#/client/" + appToken;
 		if (localStorage["accessToken"]) {
 			url += "?access_token=" + localStorage["accessToken"];


### PR DESCRIPTION
Display name was used to tell Guacamole which connection to use. Hash is now generated using the alias.
