### PR TITLE
Update root docker-compose files to new container architecture

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -41,32 +41,8 @@ postgres:
   file: ./modules/docker-compose.yml
   service: postgres
 
-apps-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: apps-module
- image: nanocloud/apps-module:indiana
-
-history-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: history-module
- image: nanocloud/history-module:indiana
-
 iaas-module:
  extends:
   file: ./modules/docker-compose.yml
   service: iaas-module
  image: nanocloud/iaas-module:indiana
-
-ldap-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: ldap-module
- image: nanocloud/ldap-module:indiana
-
-users-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: users-module
- image: nanocloud/users-module:indiana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,32 +41,8 @@ postgres:
   file: ./modules/docker-compose.yml
   service: postgres
 
-apps-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: apps-module
- image: nanocloud/apps-module:0.3.1
-
-history-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: history-module
- image: nanocloud/history-module:0.3.1
-
 iaas-module:
  extends:
   file: ./modules/docker-compose.yml
   service: iaas-module
  image: nanocloud/iaas-module:0.3.1
-
-ldap-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: ldap-module
- image: nanocloud/ldap-module:0.3.1
-
-users-module:
- extends:
-  file: ./modules/docker-compose.yml
-  service: users-module
- image: nanocloud/users-module:0.3.1


### PR DESCRIPTION
apps, history, ldap and users had been merged into nanocloud long time ago but still some container definition remained in root docker-compose files
