### PR TITLE
Disable applications page when windows instance isn't ready.

### DIFF
--- a/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
+++ b/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
@@ -22,24 +22,32 @@
 
 /// <reference path="../../../../../typings/tsd.d.ts" />
 /// <amd-dependency path="../services/ApplicationsSvc" />
+/// <amd-dependency path="../../services/services/ServicesFct" />
 /// <amd-dependency path="./ApplicationCtrl" />
 import { ApplicationsSvc, IApplication } from "../services/ApplicationsSvc";
+import { ServicesFct } from "../../services/services/ServicesFct";
 
 "use strict";
 
 export class ApplicationsCtrl {
 
 	applications: IApplication[];
+	windowsState: boolean;
 
 	static $inject = [
 		"ApplicationsSvc",
+		"ServicesFct",
 		"$mdDialog"
 	];
 
 	constructor(
 		private applicationsSrv: ApplicationsSvc,
+		private servicesFct: ServicesFct,
 		private $mdDialog: angular.material.IDialogService
 	) {
+		this.servicesFct.getWindowsStatus().then((windowsState: boolean) => {
+			this.windowsState = windowsState;
+		});
 		this.applications = [];
 		this.loadApplications();
 	}

--- a/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
+++ b/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
@@ -32,7 +32,7 @@ import { ServicesFct } from "../../services/services/ServicesFct";
 export class ApplicationsCtrl {
 
 	applications: IApplication[];
-	windowsState: boolean;
+	windowsState: boolean = false;
 
 	static $inject = [
 		"ApplicationsSvc",

--- a/webapp/website/ts/components/applications/views/applications.html
+++ b/webapp/website/ts/components/applications/views/applications.html
@@ -1,6 +1,4 @@
-
-<md-card>
-	
+<md-card ng-if="applicationsCtrl.windowsState">
 	<md-card-content>
 		<h2 class="md-title">Upload to VM</h2>
 		<div flow-init="{target: '/upload'}"
@@ -39,15 +37,13 @@
 
 </md-card>
 
-<div>
-	<md-card>
-		<md-card-content>
-			<p>
-				<strong>Windows</strong> can take some time to start all services, if you can't access <em>Desktop</em> right now, wait a minute before retrying.
-			</p>
-		</md-card-content>
-	</md-card>
-</div>
+<md-card ng-if="!applicationsCtrl.windowsState">
+	<md-card-content>
+		<p>
+			<strong>Windows</strong> seems to be unavailable, please ensure services is up and running in <strong>Services</strong> page.
+		</p>
+	</md-card-content>
+</md-card>
 
 <div ng-if="applicationsCtrl.applications.length !== 0">
 	<md-card>

--- a/webapp/website/ts/components/applications/views/applications.html
+++ b/webapp/website/ts/components/applications/views/applications.html
@@ -40,7 +40,7 @@
 <md-card ng-if="!applicationsCtrl.windowsState">
 	<md-card-content>
 		<p>
-			<strong>Windows</strong> seems to be unavailable, please ensure services is up and running in <strong>Services</strong> page.
+			<strong>Windows</strong> seems to be unavailable, please ensure services are up and running in <strong>Services</strong> page.
 		</p>
 	</md-card-content>
 </md-card>

--- a/webapp/website/ts/components/services/services/ServicesFct.ts
+++ b/webapp/website/ts/components/services/services/ServicesFct.ts
@@ -64,6 +64,17 @@ export class ServicesFct {
 		}
 	}
 
+	getWindowsStatus(): angular.IPromise<boolean> {
+		return this.servicesSvc.getAll().then((services: IService[]) => {
+			let state = false;
+			services.forEach(function(service: IService) {
+				if (service.Ico === "windows" && service.Status === "running") {
+					state = true;
+				}
+			});
+			return state;
+		});
+	}
 }
 
 angular.module("haptic.services").service("ServicesFct", ServicesFct);


### PR DESCRIPTION
Recent work from @MeoBlodnasir made IaaS API more reliable.
We can use this services to allow/forbid users to interact with features which need windows to be up and running.
