### PR TITLE
Add development container for guacamole-client

### DIFF
--- a/modules/canva/guacamole-client/Dockerfile-dev
+++ b/modules/canva/guacamole-client/Dockerfile-dev
@@ -1,0 +1,8 @@
+FROM nanocloud/guacamole-client:dev
+MAINTAINER \
+  Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
+
+RUN apt-get -y install inotify-tools
+ENV JPDA_ADDRESS=8000
+
+CMD ["sh", "-c", "(catalina.sh jpda run &) ; while inotifywait -r -e modify -e moved_to ./src ; do mvn package && touch /usr/local/tomcat/webapps/guacamole.war ; done"]

--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -2,6 +2,13 @@ guacamole-client:
  extends:
   file: ./docker-compose.yml
   service: guacamole-client
+ build: ./canva/guacamole-client
+ dockerfile: Dockerfile-dev
+ ports:
+  - 8000:8000
+ volumes:
+  - ./canva/guacamole-client/:/opt
+  - ./canva/guacamole-client/noauth-logged/target/guacamole-auth-noauthlogged-0.9.8.jar:/etc/guacamole/extensions/guacamole-auth-noauthlogged-0.9.8.jar
 
 guacamole-server:
  extends:


### PR DESCRIPTION
Guacamole-client can be built in dev mode with live reload and tomcat in debug mode
Debugger is available on port 8000 and files in modules/guacamole-client/noauth-logged/src are automatically recompiled on modifications
