### PR TITLE
Fix users could gain access all admin connections

### DIFF
--- a/modules/canva/guacamole-client/guac_home/guacamole.properties
+++ b/modules/canva/guacamole-client/guac_home/guacamole.properties
@@ -7,5 +7,3 @@ noauth-config: /etc/guacamole/noauth-config.xml
 noauthlogged-server-url: nanocloud-api
 noauthlogged-server-port: 8080
 noauthlogged-server-endpoint: api/history
-noauthlogged-server-username: admin@nanocloud.com
-noauthlogged-server-password: admin

--- a/modules/canva/guacamole-client/noauth-logged/pom.xml
+++ b/modules/canva/guacamole-client/noauth-logged/pom.xml
@@ -110,6 +110,16 @@
             <artifactId>json</artifactId>
             <version>20090211</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>3.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NoAuthLoggedGuacamoleProperties.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NoAuthLoggedGuacamoleProperties.java
@@ -66,24 +66,4 @@ public class NoAuthLoggedGuacamoleProperties {
 
     };
 
-    /**
-     * The username of the user which will perform the log request to the API
-     */
-    public static final StringGuacamoleProperty NOAUTHLOGGED_SERVERUSERNAME = new StringGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "noauthlogged-server-username"; }
-
-    };
-
-    /**
-     * The password of the user which will perform the log request to the API
-     */
-    public static final StringGuacamoleProperty NOAUTHLOGGED_SERVERPASSWORD = new StringGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "noauthlogged-server-password"; }
-
-    };
-
 }

--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NoAuthLoggedProvider.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NoAuthLoggedProvider.java
@@ -1,29 +1,15 @@
 package com.nanocloud.auth.noauthlogged;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.nanocloud.auth.noauthlogged.user.NanocloudAuthenticatedUser;
 import com.nanocloud.auth.noauthlogged.user.UserContext;
-import org.apache.commons.codec.binary.Base64;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.environment.Environment;
 import org.glyptodon.guacamole.environment.LocalEnvironment;
-import org.glyptodon.guacamole.net.auth.simple.SimpleAuthenticationProvider;
+import org.glyptodon.guacamole.net.auth.AuthenticationProvider;
 import org.glyptodon.guacamole.net.auth.AuthenticatedUser;
 import org.glyptodon.guacamole.net.auth.Credentials;
-import org.glyptodon.guacamole.properties.FileGuacamoleProperty;
-import org.glyptodon.guacamole.protocol.GuacamoleConfiguration;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
 
-import javax.json.Json;
-import javax.json.JsonObject;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Disable authentication in Guacamole. All users accessing Guacamole are
@@ -50,46 +36,16 @@ import javax.json.JsonObject;
  *
  * @author Laurent Meunier
  */
-public class NoAuthLoggedProvider extends SimpleAuthenticationProvider {
+public class NoAuthLoggedProvider implements AuthenticationProvider {
 
     private final String hostname;
     private final Integer port;
     private final String endpoint;
-    private final String username;
-    private final String password;
-    /**
-     * Logger for this class.
-     */
-    private Logger logger = LoggerFactory.getLogger(NoAuthLoggedProvider.class);
-
-    /**
-     * The last time the configuration XML was modified, as milliseconds since
-     * UNIX epoch.
-     */
-    private long configTime;
 
     /**
      * Guacamole server environment.
      */
     private final Environment environment;
-    
-    /**
-     * The XML file to read the configuration from.
-     */
-    public static final FileGuacamoleProperty NOAUTH_CONFIG = new FileGuacamoleProperty() {
-
-        @Override
-        public String getName() {
-            return "noauthlogged-config";
-        }
-
-    };
-    
-    /**
-     * The default filename to use for the configuration, if not defined within
-     * guacamole.properties.
-     */
-    public static final String DEFAULT_NOAUTH_CONFIG = "noauth-config.xml";
 
     /**
      * Creates a new NoAuthenticationProvider that does not perform any
@@ -106,147 +62,41 @@ public class NoAuthLoggedProvider extends SimpleAuthenticationProvider {
         hostname = environment.getProperty(NoAuthLoggedGuacamoleProperties.NOAUTHLOGGED_SERVERURL, "localhost");
         port = environment.getProperty(NoAuthLoggedGuacamoleProperties.NOAUTHLOGGED_SERVERPORT, 80);
         endpoint = environment.getProperty(NoAuthLoggedGuacamoleProperties.NOAUTHLOGGED_SERVERENDPOINT, "rpc");
-        username = environment.getProperty(NoAuthLoggedGuacamoleProperties.NOAUTHLOGGED_SERVERUSERNAME);
-        password = environment.getProperty(NoAuthLoggedGuacamoleProperties.NOAUTHLOGGED_SERVERPASSWORD);
 	}
     
     @Override
     public UserContext getUserContext(AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
-    	Map<String, GuacamoleConfiguration> config = getAuthorizedConfigurations(authenticatedUser.getCredentials());
-    	
-    	return new UserContext(this, authenticatedUser, config);
+        return new UserContext(this, authenticatedUser);
     }
-    
+
+    @Override
+    public org.glyptodon.guacamole.net.auth.UserContext updateUserContext(org.glyptodon.guacamole.net.auth.UserContext context, AuthenticatedUser authenticatedUser) throws GuacamoleException {
+        return context;
+    }
+
     @Override
     public String getIdentifier() {
         return "noauthlogged";
     }
 
-    private String login() throws IOException {
+    @Override
+    public AuthenticatedUser authenticateUser(Credentials credentials) throws GuacamoleException {
 
-        URL myUrl = new URL("http://" + hostname + ":" + port + "/oauth/token");
-        HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
-        //urlConn.setInstanceFollowRedirects(false);
+        String token;
+        HttpServletRequest request = credentials.getRequest();
 
-        String appKey = "9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae";
-        String appSecret = "9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341";
-        byte[] auth = Base64.encodeBase64(new String(appKey + ":" + appSecret).getBytes());
-        urlConn.setRequestProperty("Authorization", "Basic OTQwNWZiNmIwZTU5ZDI5OTdlM2M3NzdhMjJkOGYwZTYxN2E5ZjViMzZiNjU2NWM3NTc5ZTViZTZkZWI4ZjdhZTo5MDUwZDY3YzJiZTA5NDNmMmM2MzUwNzA1MmRkZWRiM2FlMzRhMzBlMzliYmJiZGFiMjQxYzkzZjhiNWNmMzQx");
-        urlConn.setRequestProperty("Content-Type", "application/json");
-
-        JsonObject params = Json.createObjectBuilder()
-                .add("username", username)
-                .add("password", password)
-                .add("grant_type", "password")
-                .build();
-
-        urlConn.setUseCaches(false);
-        urlConn.setDoOutput(true);
-        // Send request (for some reason we actually need to wait for response)
-        DataOutputStream writer = new DataOutputStream(urlConn.getOutputStream());
-        writer.writeBytes(params.toString());
-        writer.close();
-
-        urlConn.connect();
-        urlConn.getOutputStream().close();
-
-        // Get Response
-        InputStream input = urlConn.getInputStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
-        StringBuilder response = new StringBuilder();
-
-        String line;
-        while ((line = reader.readLine()) != null) {
-            response.append(line);
+        if (request.getParameter("access_token").isEmpty()) {
+            throw new GuacamoleException("An access_token must be specified");
         }
-        reader.close();
+        token = request.getParameter("access_token");
 
-        JSONObject json = null;
-        try {
-            json = new JSONObject(response.toString());
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-        String token = null;
-        try {
-            token = json.getString("access_token");
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-
-        return token;
-    }
-
-    private Map<String, GuacamoleConfiguration> askForConnections() throws IOException, JSONException {
-
-        Map<String, GuacamoleConfiguration> configs = new HashMap<String, GuacamoleConfiguration>();
-
-        String token = login();
-
-        URL myUrl = new URL("http://" + hostname + ":" + port + "/api/apps/connections");
-        HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
-
-        urlConn.setInstanceFollowRedirects(false);
-        urlConn.setRequestProperty("Authorization", "Bearer " + token);
-        urlConn.setUseCaches(false);
-
-        urlConn.connect();
-
-        // Get Response
-        InputStream input = urlConn.getInputStream();
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
-        StringBuilder response = new StringBuilder();
-
-        String line;
-        while ((line = reader.readLine()) != null) {
-            response.append(line);
-        }
-        reader.close();
-
-        System.out.println(response.toString());
-        JSONArray appList =  new JSONArray(response.toString());
-        for (int i = 0; i < appList.length(); i++) {
-            JSONObject connection = appList.getJSONObject(i);
-            GuacamoleConfiguration config = new GuacamoleConfiguration();
-
-            config.setProtocol(connection.getString("protocol"));
-            config.setParameter("hostname", connection.getString("hostname"));
-            config.setParameter("port", connection.getString("port"));
-            config.setParameter("username", connection.getString("username"));
-            config.setParameter("password", connection.getString("password"));
-            config.setParameter("security", "nla");
-            config.setParameter("ignore-cert", "true");
-            if (connection.has("remote_app")) {
-                config.setParameter("remote-app", connection.getString("remote_app"));
-            }
-
-            configs.put(connection.getString("app_name"), config);
-        }
-
-        return configs;
+        return new NanocloudAuthenticatedUser(this, token);
     }
 
     @Override
-    public Map<String, GuacamoleConfiguration> getAuthorizedConfigurations(Credentials credentials) throws GuacamoleException {
-
-        Map<String, GuacamoleConfiguration> configs = null;
-
-        logger.info("Fetch application list from server");
-
-        try {
-            configs = askForConnections();
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-
-        logger.info("Application list fetched");
-
-        return configs;
-
+    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser, Credentials credentials) throws GuacamoleException {
+        return authenticatedUser;
     }
+
 }

--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/NanocloudAuthenticatedUser.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/NanocloudAuthenticatedUser.java
@@ -1,0 +1,52 @@
+package com.nanocloud.auth.noauthlogged.user;
+
+import com.google.inject.Inject;
+import org.glyptodon.guacamole.net.auth.AuthenticatedUser;
+import org.glyptodon.guacamole.net.auth.AuthenticationProvider;
+import org.glyptodon.guacamole.net.auth.Credentials;
+
+public class NanocloudAuthenticatedUser implements AuthenticatedUser {
+
+    /**
+     * Reference to the authentication provider associated with this
+     * authenticated user.
+     */
+    @Inject
+    private AuthenticationProvider authProvider;
+
+    protected String token = null;
+
+    @Override
+    public AuthenticationProvider getAuthenticationProvider() {
+        return this.authProvider;
+    }
+
+    @Override
+    public NanocloudCredentials getCredentials() {
+        return new NanocloudCredentials(this.token);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return this.token;
+    }
+
+    @Override
+    public void setIdentifier(String identifier) {
+        this.token = identifier;
+    }
+
+    public NanocloudAuthenticatedUser(AuthenticationProvider authprovider, String token) {
+
+        this.authProvider = authprovider;
+        this.token = token;
+    }
+
+    private class NanocloudCredentials extends Credentials {
+
+        public NanocloudCredentials(String token) {
+
+            this.setUsername(token);
+        }
+    }
+}

--- a/nanocloud/routes/apps/apps.go
+++ b/nanocloud/routes/apps/apps.go
@@ -24,11 +24,12 @@ package apps
 
 import (
 	"encoding/json"
+	"strings"
+
 	"github.com/Nanocloud/community/nanocloud/models/apps"
 	"github.com/Nanocloud/community/nanocloud/models/users"
 	"github.com/Nanocloud/community/nanocloud/router"
 	log "github.com/Sirupsen/logrus"
-	"strings"
 )
 
 type hash map[string]interface{}
@@ -46,7 +47,7 @@ func GetConnections(req router.Request) (*router.Response, error) {
 			"error": "Unable to retrieve users",
 		}), nil
 	}
-	connections, err := apps.RetrieveConnections(userList)
+	connections, err := apps.RetrieveConnections(req.User, userList)
 	if err == apps.AppsListUnavailable {
 		return router.JSONResponse(500, hash{
 			"error": "Unable to retrieve applications list",

--- a/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
+++ b/webapp/website/ts/components/applications/controllers/ApplicationsCtrl.ts
@@ -34,6 +34,8 @@ export class ApplicationsCtrl {
 	applications: IApplication[];
 	windowsState: boolean = false;
 
+	private accessToken: string;
+
 	static $inject = [
 		"ApplicationsSvc",
 		"ServicesFct",
@@ -48,6 +50,7 @@ export class ApplicationsCtrl {
 		this.servicesFct.getWindowsStatus().then((windowsState: boolean) => {
 			this.windowsState = windowsState;
 		});
+		this.accessToken = localStorage["accessToken"];
 		this.applications = [];
 		this.loadApplications();
 	}

--- a/webapp/website/ts/components/applications/views/applications.html
+++ b/webapp/website/ts/components/applications/views/applications.html
@@ -23,12 +23,12 @@
 	</md-card-content>
 
 	<md-card-actions layout="row" layout-align="end center">
-		<md-button href="/guacamole/#/client/aGFwdGljRGVza3RvcABjAG5vYXV0aGxvZ2dlZA=="
+		<md-button href="/guacamole/#/client/aGFwdGljRGVza3RvcABjAG5vYXV0aGxvZ2dlZA==?access_token={{ applicationsCtrl.accessToken }}"
 				target="_blank" class="md-raised">
 			<md-tooltip>Open Windows desktop to install your application</md-tooltip>
 			<ng-md-icon icon="windows"></ng-md-icon> Desktop
 		</md-button>
-		<md-button href="/guacamole/#/client/aGFwdGljUG93ZXJzaGVsbABjAG5vYXV0aGxvZ2dlZA=="
+		<md-button href="/guacamole/#/client/aGFwdGljUG93ZXJzaGVsbABjAG5vYXV0aGxvZ2dlZA==?access_token={{ applicationsCtrl.accessToken }}"
 				target="_blank" class="md-raised md-primary">
 			<md-tooltip>Publish an application</md-tooltip>
 			<ng-md-icon icon="cloud_done"></ng-md-icon> Publish


### PR DESCRIPTION
Guacamole get the user token and use it to perform API call to Nanocloud instead of getting a token as an admin
List connections now returns the current user's connections only
Now guacamole relies on the given user token to retrieve connection, the admin token must be sent as a get parameter when clicking "Desktop" or "Publish" button.
