### PR TITLE
Fix error 500 when guacamole tried to fetch group connections

### DIFF
--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
@@ -37,6 +37,9 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 	private static final String ROOT_IDENTIFIER = "ROOT";
 	private final LocalEnvironment environment;
 	private final AuthenticatedUser authenticatedUser;
+	private final SimpleUserDirectory userDirectory;
+	private final SimpleConnectionGroupDirectory connectionGroupDirectory;
+	private final SimpleConnectionGroup rootGroup;
 
 	/**
 	 * Logger for this class.
@@ -59,6 +62,13 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 		this.self = new SimpleUser(authenticatedUser.getIdentifier(), new ArrayList<String>(0),
 				Collections.singleton(ROOT_IDENTIFIER));
 
+		this.rootGroup = new SimpleConnectionGroup(
+				ROOT_IDENTIFIER, ROOT_IDENTIFIER,
+				new ArrayList<String>(0), Collections.<String>emptyList()
+		);
+		this.userDirectory = new SimpleUserDirectory(self);
+		this.connectionGroupDirectory = new SimpleConnectionGroupDirectory(Collections.<ConnectionGroup>singleton(this.rootGroup));
+
 		// Associate provided AuthenticationProvider
 		this.authProvider = authProvider;
 	}
@@ -75,7 +85,7 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 
 	@Override
 	public Directory<User> getUserDirectory() throws GuacamoleException {
-		return null;
+		return this.userDirectory;
 	}
 
 	@Override
@@ -107,7 +117,7 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 
 	@Override
 	public Directory<ConnectionGroup> getConnectionGroupDirectory() throws GuacamoleException {
-		return null;
+		return this.connectionGroupDirectory;
 	}
 
 	@Override
@@ -117,7 +127,7 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 
 	@Override
 	public ConnectionGroup getRootConnectionGroup() throws GuacamoleException {
-		return null;
+		return this.rootGroup;
 	}
 
 	@Override

--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
@@ -81,7 +81,6 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 	@Override
 	public Directory<Connection> getConnectionDirectory() throws GuacamoleException {
 
-		System.out.println("UserContext : getConnectionDirectory");
 		Map<String, GuacamoleConfiguration> configs = this.getAuthorizedConfigurations();
 		Collection<String> connectionIdentifiers = new ArrayList<String>(configs.size());
 
@@ -163,7 +162,6 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 		}
 		reader.close();
 
-		System.out.println(response.toString());
 		JSONObject jsonResponse =  new JSONObject(response.toString());
 		JSONArray appList = jsonResponse.getJSONArray("data");
 		for (int i = 0; i < appList.length(); i++) {


### PR DESCRIPTION
Fix a non critical error where Guacamole was trying to get connection groups and instead get null which resolved to a nullPointerException
Given that connections are resolved at each requests, this patch only returns the empty group list necessary for the call to succeed
Remove debug log that should not have been commited in the first place
