### PR TITLE
Communicate with Iaas through HTTP instead of AMQ

### DIFF
--- a/modules/iaas/Dockerfile
+++ b/modules/iaas/Dockerfile
@@ -15,4 +15,5 @@ WORKDIR /go/src/github.com/Nanocloud/community/modules/iaas
 
 RUN go get ./... && go build
 
+EXPOSE 8080
 CMD ["./iaas"]

--- a/modules/iaas/main.go
+++ b/modules/iaas/main.go
@@ -156,10 +156,10 @@ func main() {
 		iaasCon: iaas.New(conf.Server, conf.Password, conf.User, conf.SSHPort, conf.instDir, conf.artURL),
 	}
 
-	e.Get("/iaas", h.ListRunningVM)
-	e.Post("/iaas/:id/stop", h.StopVM)
-	e.Post("/iaas/:id/start", h.StartVM)
-	e.Post("/iaas/:id/download", h.DownloadVM)
+	e.Get("/api/iaas", h.ListRunningVM)
+	e.Post("/api/iaas/:id/stop", h.StopVM)
+	e.Post("/api/iaas/:id/start", h.StartVM)
+	e.Post("/api/iaas/:id/download", h.DownloadVM)
 
 	e.Run(":8080")
 }

--- a/modules/iaas/main.go
+++ b/modules/iaas/main.go
@@ -21,10 +21,14 @@
 package main
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/Nanocloud/community/modules/iaas/lib/iaas"
 	"github.com/Nanocloud/nano"
+	log "github.com/Sirupsen/logrus"
+	"github.com/labstack/echo"
+	mw "github.com/labstack/echo/middleware"
 )
 
 var module nano.Module
@@ -46,90 +50,75 @@ type handler struct {
 
 var conf Configuration
 
-func AdminOnly(req nano.Request) (*nano.Response, error) {
-	if req.User != nil && !req.User.IsAdmin {
-		return nano.JSONResponse(403, hash{
-			"error": "forbidden",
-		}), nil
-	}
-	return nil, nil
-}
-
-func (h *handler) ListRunningVM(req nano.Request) (*nano.Response, error) {
+func (h *handler) ListRunningVM(c *echo.Context) error {
 	response, err := h.iaasCon.GetList()
 	if err != nil {
-		module.Log.Error("Unable to retrieve VM states list")
-		return nano.JSONResponse(500, hash{
+		log.Error("Unable to retrieve VM states list")
+		return c.JSON(http.StatusInternalServerError, hash{
 			"error": "Unable te retrieve states of VMs: " + err.Error(),
-		}), nil
+		})
 	}
 
 	vmList := h.iaasCon.CheckVMStates(response)
-	return nano.JSONResponse(200, vmList), nil
+	return c.JSON(http.StatusOK, vmList)
 }
 
-func (h *handler) DownloadVM(req nano.Request) (*nano.Response, error) {
-	var params = map[string]string{
-		"vmname": req.Params["id"],
-	}
+func (h *handler) DownloadVM(c *echo.Context) error {
+	vmname := c.Param("id")
 
-	if params["vmname"] == "" {
-		return nano.JSONResponse(400, hash{
+	if vmname == "" {
+		return c.JSON(http.StatusBadRequest, hash{
 			"error": "No VM ID provided",
-		}), nil
+		})
 	}
 
-	go h.iaasCon.Download(params["vmname"])
-	return nano.JSONResponse(202, hash{
+	go h.iaasCon.Download(vmname)
+	return c.JSON(http.StatusOK, hash{
 		"success": true,
-	}), nil
+	})
 }
 
-func (h *handler) StartVM(req nano.Request) (*nano.Response, error) {
-	var params = map[string]string{
-		"name": req.Params["id"],
-	}
+func (h *handler) StartVM(c *echo.Context) error {
+	name := c.Param("id")
 
-	if params["name"] == "" {
-		return nano.JSONResponse(400, hash{
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, hash{
 			"error": "No VM name provided",
-		}), nil
+		})
 	}
 
-	err := h.iaasCon.Start(params["name"])
+	err := h.iaasCon.Start(name)
 	if err != nil {
-		module.Log.Error("Error while starting VM")
-		return nano.JSONResponse(500, hash{
+		log.Error("Error while starting VM")
+		return c.JSON(http.StatusInternalServerError, hash{
 			"error": "Unable to start the specified VM",
-		}), err
+		})
 	}
 
-	return nano.JSONResponse(200, hash{
+	return c.JSON(http.StatusOK, hash{
 		"success": true,
-	}), nil
+	})
 }
 
-func (h *handler) StopVM(req nano.Request) (*nano.Response, error) {
-	var params = map[string]string{
-		"Name": req.Params["id"],
-	}
+func (h *handler) StopVM(c *echo.Context) error {
+	name := c.Param("id")
 
-	if params["Name"] == "" {
-		return nano.JSONResponse(400, hash{
+	if name == "" {
+		return c.JSON(http.StatusBadRequest, hash{
 			"error": "No VM name provided",
-		}), nil
+		})
 	}
 
-	err := h.iaasCon.Stop(params["Name"])
+	err := h.iaasCon.Stop(name)
 	if err != nil {
-		return nano.JSONResponse(500, hash{
+		return c.JSON(http.StatusInternalServerError, hash{
 			"error": "Unable to stop the specified VM",
-		}), err
+		})
 	}
 
-	return nano.JSONResponse(200, hash{
+	return c.JSON(http.StatusOK, hash{
 		"success": true,
-	}), nil
+	})
 }
 
 func env(key, def string) string {
@@ -141,8 +130,6 @@ func env(key, def string) string {
 }
 
 func main() {
-	module = nano.RegisterModule("iaas")
-
 	conf.Server = env("SERVER", "127.0.0.1")
 	conf.Password = env("PASSWORD", "ItsPass1942+")
 	conf.User = env("USER", "Administrator")
@@ -158,14 +145,21 @@ func main() {
 		conf.artURL = "http://releases.nanocloud.org:8080/releases/latest/"
 	}
 
+	// Echo instance
+	e := echo.New()
+
+	// Middleware
+	e.Use(mw.Logger())
+	e.Use(mw.Recover())
+
 	h := handler{
 		iaasCon: iaas.New(conf.Server, conf.Password, conf.User, conf.SSHPort, conf.instDir, conf.artURL),
 	}
 
-	module.Get("/iaas", AdminOnly, h.ListRunningVM)
-	module.Post("/iaas/:id/stop", AdminOnly, h.StopVM)
-	module.Post("/iaas/:id/start", AdminOnly, h.StartVM)
-	module.Post("/iaas/:id/download", AdminOnly, h.DownloadVM)
+	e.Get("/iaas", h.ListRunningVM)
+	e.Post("/iaas/:id/stop", h.StopVM)
+	e.Post("/iaas/:id/start", h.StartVM)
+	e.Post("/iaas/:id/download", h.DownloadVM)
 
-	module.Listen()
+	e.Run(":8080")
 }

--- a/nanocloud/main.go
+++ b/nanocloud/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Nanocloud/community/nanocloud/routes/apps"
 	"github.com/Nanocloud/community/nanocloud/routes/front"
 	"github.com/Nanocloud/community/nanocloud/routes/history"
+	"github.com/Nanocloud/community/nanocloud/routes/iaas"
 	"github.com/Nanocloud/community/nanocloud/routes/me"
 	"github.com/Nanocloud/community/nanocloud/routes/oauth"
 	"github.com/Nanocloud/community/nanocloud/routes/upload"
@@ -81,6 +82,14 @@ func main() {
 	router.Delete("/users/:id", middlewares.OAuth2, middlewares.Admin, users.Delete)
 	router.Put("/users/:id", middlewares.OAuth2, middlewares.Admin, users.UpdatePassword)
 	router.Get("/users/:id", middlewares.OAuth2, middlewares.Admin, users.GetUser)
+
+	/**
+	 * IAAS
+	 */
+	router.Get("/iaas", middlewares.OAuth2, middlewares.Admin, iaas.ListRunningVM)
+	router.Post("/iaas/:id/stop", middlewares.OAuth2, middlewares.Admin, iaas.StopVM)
+	router.Post("/iaas/:id/start", middlewares.OAuth2, middlewares.Admin, iaas.StartVM)
+	router.Post("/iaas/:id/download", middlewares.OAuth2, middlewares.Admin, iaas.DownloadVM)
 
 	/**
 	 * FRONT

--- a/nanocloud/routes/iaas/iaas.go
+++ b/nanocloud/routes/iaas/iaas.go
@@ -1,0 +1,59 @@
+package iaas
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/Nanocloud/community/nanocloud/router"
+	"github.com/labstack/gommon/log"
+)
+
+const (
+	iaasAPIurl = "http://iaas-module:8080"
+)
+
+func proxy(req *router.Request) (*router.Response, error) {
+	r := req.Request()
+	path := r.URL.Path
+
+	var resp *http.Response
+	var err error
+
+	if r.Method == "GET" {
+		resp, err = http.Get(iaasAPIurl + path)
+	} else {
+		resp, err = http.Post(iaasAPIurl+path, "", nil)
+	}
+
+	if err != nil {
+		log.Error(err)
+		return nil, errors.New("Unable to contact Iaas API")
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+		return nil, errors.New("Unable to contact Iaas API")
+	}
+
+	contentType := ""
+
+	ct := resp.Header["Content-Type"]
+	if len(ct) > 0 {
+		contentType = ct[0]
+	}
+
+	return &router.Response{
+		StatusCode:  resp.StatusCode,
+		ContentType: contentType,
+		Body:        body,
+	}, nil
+}
+
+var (
+	ListRunningVM = proxy
+	StopVM        = proxy
+	StartVM       = proxy
+	DownloadVM    = proxy
+)


### PR DESCRIPTION
Turns Iaas module to an HTTP server instead of a AMQ consumer.
By doing so, we don't need RabbitMQ anymore, we will be able to replace our custom router by echo and we do not use the nano library anymore. (Such changes will appear later in different PR)
