### PR TITLE
HOTFIX windows launch script not mounted in dev mode

### DIFF
--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -74,4 +74,5 @@ iaas-module:
  dockerfile: Dockerfile-dev
  volumes:
   - ./iaas/:/go/src/github.com/Nanocloud/community/modules/iaas/
+  - ./iaas/scripts/:/var/lib/nanocloud/scripts
   - ../installation_dir/:/var/lib/nanocloud


### PR DESCRIPTION
Windows could not be launched in dev mode since launch script was moved to iaas/scripts
