### PR TITLE
The windows popup will only pop if publishapp is called without an argument + new timeout on the popup

### DIFF
--- a/windows/floppy/windows-2012-standard-amd64/publishApplication.ps1
+++ b/windows/floppy/windows-2012-standard-amd64/publishApplication.ps1
@@ -26,5 +26,7 @@ $displayName = [io.path]::GetFileNameWithoutExtension($filename)
 New-RDRemoteApp -CollectionName $collectionName -DisplayName $displayName -FilePath $filename
 
 # *** Display a popup ***
+if (-Not $args[0]) {
 $wshell = New-Object -ComObject Wscript.Shell
-$wshell.Popup($displayName+ " has been published ! You can now close this tab.", 0, "Done", 0x1)
+$wshell.Popup($displayName+ " has been published ! You can now close this tab.", 10, "Done", 0x1)
+}


### PR DESCRIPTION
The popup prevented the publish app call on the API to work, since the OK button was never pressed, so it now displays only when its called with the Publish button on the interface. Also, is someone doesn't click OK and closes the tab, the popup will timeout anyway.
