### PR TITLE
Allow to run Nanocloud in test mode with no mapped port

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -40,6 +40,9 @@ proxy:
  extends:
   file: ./modules/docker-compose.yml
   service: proxy
+ ports:
+  - 80:80
+  - 443:443
 
 postgres:
  extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ proxy:
  extends:
   file: ./modules/docker-compose.yml
   service: proxy
+ ports:
+  - 80:80
+  - 443:443
 
 postgres:
  extends:

--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -60,6 +60,9 @@ proxy:
  extends:
   file: ./docker-compose.yml
   service: proxy
+ ports:
+  - 80:80
+  - 443:433
 
 postgres:
  extends:

--- a/modules/docker-compose-test.yml
+++ b/modules/docker-compose-test.yml
@@ -36,9 +36,6 @@ proxy:
  extends:
   file: ./docker-compose.yml
   service: proxy
- ports:
-  - 80:80
-  - 443:443
 
 postgres:
  extends:

--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -48,9 +48,6 @@ nanocloud-canva:
 
 proxy:
  build: ./nginx
- ports:
-  - 80:80
-  - 443:443
  restart: always
  container_name: "proxy"
 


### PR DESCRIPTION
docker-compose-test.yml run Nanocloud in its local network with no bound port
