### PR TITLE
Fix bug nanocloud/proxy was built even in production mode

### DIFF
--- a/docker-compose-indiana.yml
+++ b/docker-compose-indiana.yml
@@ -43,6 +43,7 @@ proxy:
  ports:
   - 80:80
   - 443:443
+ image: nanocloud/proxy:indiana
 
 postgres:
  extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ proxy:
  ports:
   - 80:80
   - 443:443
+ image: nanocloud/proxy:0.4.0rc1
 
 postgres:
  extends:


### PR DESCRIPTION
Update production docker-compose file to use nanocloud/proxy from Docker Hub
