### PR TITLE
Fix bug nanocloud frontend was not accessible in dev mode

### DIFF
--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -62,7 +62,7 @@ proxy:
   service: proxy
  ports:
   - 80:80
-  - 443:433
+  - 443:443
 
 postgres:
  extends:


### PR DESCRIPTION
A typo in docker-compose-dev.yml prevented port 443 to be correctly bound
