### PR TITLE
fixed cursor lag

### DIFF
--- a/modules/canva/frontend/app/components/guac-session.js
+++ b/modules/canva/frontend/app/components/guac-session.js
@@ -146,12 +146,17 @@ export default Ember.Component.extend({
 
     let mouse = new Guacamole.Mouse(this.guacamole.getDisplay().getElement());
     let keyboard = new Guacamole.Keyboard(document);
+    let display = this.guacamole.getDisplay();
 
     this.guacamole.connect();
 
     mouse.onmousedown = mouse.onmouseup = mouse.onmousemove = function(mouseState) {
       this.guacamole.sendMouseState(mouseState);
     }.bind(this);
+
+    display.oncursor = function(canvas, x, y) {
+      display.showCursor(!mouse.setCursor(canvas, x, y));
+    }
 
     keyboard.onkeydown = function (keysym) {
       this.guacamole.sendKeyEvent(1, keysym);

--- a/modules/canva/frontend/app/styles/app.css
+++ b/modules/canva/frontend/app/styles/app.css
@@ -1,8 +1,6 @@
 body {
     background: black;
-    cursor: url('images/mouse/blank.gif'),url('images/mouse/blank.cur'),default;
     overflow: hidden;
-    cursor: none;
 }
 
 .guac-session {


### PR DESCRIPTION
Note that since IE requires .ani or .cur image formats for the 'cursor' css property, and that guacamole client receives .png images, the lag is still present on IE.
