### PR TITLE
A user connection now has the user sam and the windows domain in its username

### DIFF
--- a/nanocloud/models/apps/apps.go
+++ b/nanocloud/models/apps/apps.go
@@ -341,12 +341,7 @@ func RetrieveConnections(user *users.User, users *[]users.User) ([]Connection, e
 		} else {
 			execServ = kServer
 		}
-		var username string
-		if user.Sam == "Administrator" {
-			username = user.Sam + "@" + kWindowsDomain
-		} else {
-			username = user.Sam
-		}
+		username := user.Sam + "@" + kWindowsDomain
 		pwd := user.WindowsPassword
 		var conn Connection
 		if appParam.Alias != "Desktop" {


### PR DESCRIPTION
When the active directory and the execution server are 2 separate windows instances, the user couldn't login. Now his credentials a correctly set.
