### PR TITLE
Add test mode for nanocloud

### DIFF
--- a/modules/docker-compose-test.yml
+++ b/modules/docker-compose-test.yml
@@ -1,48 +1,55 @@
-guacamole-client:
- extends:
-  file: ./docker-compose.yml
-  service: guacamole-client
+version: '2'
 
-guacamole-server:
- extends:
-  file: ./docker-compose.yml
-  service: guacamole-server
+services:
+ guacamole-client:
+  extends:
+   file: ./docker-compose.yml
+   service: guacamole-client
 
-nanocloud-backend:
- extends:
-  file: ./docker-compose.yml
-  service: nanocloud-backend
- volumes_from:
-  - nanocloud-frontend
-  - nanocloud-canva
+ guacamole-server:
+  extends:
+   file: ./docker-compose.yml
+   service: guacamole-server
 
-nanocloud-frontend:
- extends:
-  file: ./docker-compose.yml
-  service: nanocloud-frontend
- volumes:
-  - /opt/front
- container_name: "nanocloud-frontend"
+ nanocloud-backend:
+  extends:
+   file: ./docker-compose.yml
+   service: nanocloud-backend
+  volumes_from:
+   - nanocloud-frontend
+   - nanocloud-canva
 
-nanocloud-canva:
- extends:
-  file: ./docker-compose.yml
-  service: nanocloud-canva
- volumes:
-  - /opt/canva
- container_name: "nanocloud-canva"
+ nanocloud-frontend:
+  extends:
+   file: ./docker-compose.yml
+   service: nanocloud-frontend
+  volumes:
+   - /opt/front
+  container_name: "nanocloud-frontend"
 
-proxy:
- extends:
-  file: ./docker-compose.yml
-  service: proxy
+ nanocloud-canva:
+  extends:
+   file: ./docker-compose.yml
+   service: nanocloud-canva
+  volumes:
+   - /opt/canva
+  container_name: "nanocloud-canva"
 
-postgres:
- extends:
-  file: ./docker-compose.yml
-  service: postgres
+ proxy:
+  extends:
+   file: ./docker-compose.yml
+   service: proxy
 
-iaas-module:
- extends:
-  file: ./docker-compose.yml
-  service: iaas-module
+ postgres:
+  extends:
+   file: ./docker-compose.yml
+   service: postgres
+
+ iaas-module:
+  extends:
+   file: ./docker-compose.yml
+   service: iaas-module
+
+networks:
+ nanocloud:
+  driver: bridge

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tests/Dockerfile-api-tests
+++ b/tests/Dockerfile-api-tests
@@ -6,4 +6,4 @@ COPY ./ /opt
 
 WORKDIR /opt
 
-CMD newman -x --insecure -c /opt/api/APItests.postman_collection -e /opt/api/NanoEnv.postman_environment
+CMD newman -x --insecure -c /opt/api/APItests.postman_collection -e /opt/api/NanoEnv.postman_environment -r 1200000

--- a/tests/Dockerfile-api-tests
+++ b/tests/Dockerfile-api-tests
@@ -1,0 +1,9 @@
+FROM node:0.10.42
+MAINTAINER Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
+
+RUN npm install -g newman
+COPY ./ /opt
+
+WORKDIR /opt
+
+CMD newman -x --insecure -c /opt/api/APItests.postman_collection -e /opt/api/NanoEnv.postman_environment

--- a/tests/Dockerfile-api-tests
+++ b/tests/Dockerfile-api-tests
@@ -1,7 +1,7 @@
 FROM node:0.10.42
 MAINTAINER Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
-RUN npm install -g newman
+RUN npm install -g newman@1
 COPY ./ /opt
 
 WORKDIR /opt

--- a/tests/Dockerfile-api-tests
+++ b/tests/Dockerfile-api-tests
@@ -6,4 +6,4 @@ COPY ./ /opt
 
 WORKDIR /opt
 
-CMD newman -x --insecure -c /opt/api/APItests.postman_collection -e /opt/api/NanoEnv.postman_environment -r 1200000
+CMD newman -x --insecure -c /opt/api/APItests.postman_collection -e /opt/api/NanoEnv.postman_environment -r 120000

--- a/tests/api/NanoEnv.postman_environment
+++ b/tests/api/NanoEnv.postman_environment
@@ -4,7 +4,7 @@
 	"values": [
 		{
 			"key": "PROTOCOL",
-			"value": "http",
+			"value": "https",
 			"type": "text",
 			"name": "PROTOCOL",
 			"enabled": true

--- a/tests/notify-github.js
+++ b/tests/notify-github.js
@@ -1,0 +1,89 @@
+#!/usr/bin/nodejs
+/*
+ * Nanocloud Community, a comprehensive platform to turn any application
+ * into a cloud solution.
+ *
+ * Copyright (C) 2015 Nanocloud Software
+ *
+ * This file is part of Nanocloud community.
+ *
+ * Nanocloud community is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud community is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var proc = require('child_process');
+
+/*
+ * Example params:
+ * {
+ *   github_password,
+ *   pull_sha,
+ *   state,
+ *   description,
+ *   context,
+ *   url
+ * }
+ */
+var notify = function(params) {
+  
+  var command = 'curl -H "Authorization: token ' + params.github_password + '" --request POST -k --data \'{\"state\": \"'+ params.state +'\", \"description\": \"'+ params.description +'\", \"context\": \"'+ params.context +'\", \"target_url\": \"' + params.url + '\"}\' https://api.github.com/repos/nanocloud/community/statuses/' + params.pull_sha;
+
+    console.log("Notify github with command: " + command)
+    proc.exec(command, function (err, stdout, stderr) {
+	if (err) {
+	    console.log("Error contacting gitHub: " + stderr);
+	} else {
+	    console.log("Github notify completed")
+	    console.log(stdout)
+	}
+    });
+}
+
+var _usage = false;
+
+var usage = function() {
+  if (_usage == false) {
+    console.log("Usage: notify-github: pull_sha state description context url");
+    console.log("Expects github_password to be set in environment");
+
+    _usage = true;
+  }
+
+  return _usage;
+}
+
+// If directly invoked from command line
+// Usage: notify-github: pull_sha state description context url
+// Expects github_password to be set in environment
+if (require.main === module) {
+
+  var pull_sha = process.argv[2] || usage.call();
+  var state = process.argv[3] || usage.call();
+  var description = process.argv[4] || usage.call();
+  var context = process.argv[5] || usage.call();
+  var url = process.argv[6] || usage.call();
+  var github_password = global.process.env["github_password"] || usage();
+
+  if (_usage == false) {
+    notify({
+      github_password: github_password,
+      pull_sha: pull_sha,
+      state: state,
+      description: description,
+      context: context,
+      url: url
+    });
+  }
+}
+
+module.exports.notify = notify;

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nanocloud-tests",
+  "version": "0.4.0",
+  "description": "Tests suits for Nanocloud Community edition",
+  "main": "run-tests.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@bitbucket.org:nanocloud/build-tools.git"
+  },
+  "author": "Olivier Berthonneau <olivier.berthonneau@nanocloud.com>",
+  "license": "AGPL-3.0",
+  "dependencies": {
+    "async": "^1.5.2"
+  }
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -85,7 +85,7 @@ function bootWindows(next) {
 }
 
 function waitForWindowsToBeRunning(next) {
-  console.log("Wainting for Windows to be running....");
+  console.log("Waiting for Windows to be running....");
   request({
     path: '/api/iaas',
     verb: 'GET',

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -122,8 +122,7 @@ function login(next) {
   }, function(res) {
     TOKEN = res.access_token;
     console.log("Got token : " + TOKEN);
-    if (next)
-      next();
+    next();
   });
 }
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -15,16 +15,16 @@ function waitForNanocloudToBeOnline() {
   try {
     var returnedValue = proc.execSync(command);
   } catch (e) {
-    waitForNanocloudToBeOnline();
+    setInterval(waitForNanocloudToBeOnline, 2000);
   }
 
-  if (returnedValue.toString() == "200\n") {
+  if (returnedValue && returnedValue.toString() == "200\n") {
     console.log("Nanocloud available");
 
     return ;
   }
 
-  waitForNanocloudToBeOnline();
+  setInterval(waitForNanocloudToBeOnline, 2000);
 }
 
 function setHost() {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -131,10 +131,16 @@ function setHostInEnv(next) {
   var command = 'sed -i "s/value\\": \\"127.0.0.1\\"/value\\": \\"$(docker exec proxy hostname -I | awk \'{print $1}\')\\"/g" api/NanoEnv.postman_environment'
 
   console.log("Setting host in api file")
-  var returnedValue = proc.execSync(command);
+  proc.exec(command, function (err, stdout, stderr) {
 
-  console.log(returnedValue.toString());
-  next();
+    if (err) {
+      console.log(stdout);
+      console.log(stderr);
+      throw "Cannot set host in environment file"
+    }
+    return next();
+
+  });
 }
 
 function done() {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -66,7 +66,9 @@ function waitForNanocloudToBeOnline(next) {
       }
     }
 
-    setInterval(waitForNanocloudToBeOnline, 2000);
+    setTimeout(function () {
+      waitForNanocloudToBeOnline(next);
+    }, 2000);
   });
 
 }

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -83,6 +83,7 @@ function setHost(next) {
 }
 
 function bootWindows(next) {
+  console.log("Booting Windows");
   request({
     path: '/api/iaas/windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64/start',
     verb: 'POST'
@@ -149,4 +150,3 @@ async.waterfall([
   waitForWindowsToBeRunning,
   done
 ])
-

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,152 @@
+#!/usr/bin/nodejs
+
+var http = require('https');
+var proc = require('child_process');
+var async = require("async");
+var HOST = null;
+var TOKEN = null;
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+function waitForNanocloudToBeOnline() {
+  var command = 'curl --output /dev/null --insecure --silent --write-out \'%{http_code}\n\' "https://$(docker exec proxy hostname -I | awk \'{print $1}\')"';
+
+  console.log("Try to connect")
+  try {
+    var returnedValue = proc.execSync(command);
+  } catch (e) {
+    waitForNanocloudToBeOnline();
+  }
+
+  if (returnedValue.toString() == "200\n") {
+    console.log("Nanocloud available");
+
+    return ;
+  }
+
+  waitForNanocloudToBeOnline();
+}
+
+function setHost() {
+  var command = "docker exec proxy hostname -I | awk \'{print $1}\'";
+
+  console.log("Determining host")
+  var returnedValue = proc.execSync(command);
+
+  HOST = returnedValue.toString().trim();
+  console.log("Host address: " + HOST)
+}
+
+function request(options, callback) {
+  var message = "";
+  var status = null;
+
+  var headers = options.headers || {};
+  var param = JSON.stringify(options.param) || "";
+
+  if (TOKEN) {
+    headers.Authorization = "Bearer " + TOKEN
+  }
+
+  var options = {
+    host: HOST,
+    path: options.path,
+    method: options.verb,
+    port: 443,
+    headers: headers
+  };
+
+  var req = http.request(options, function(res) {
+    status = res.statusCode;
+
+    res.setEncoding('utf8');
+    res.on('data', function(chunk) {
+      message += chunk;
+    });
+    res.on('end', function() {
+      console.log("Call to " + options.path + " returned " + status)
+      if (callback && status == 200)
+        callback(JSON.parse(message));
+      if (status != 200)
+        console.log(message);
+    })
+  });
+
+  req.on('error', function(e) {
+    console.log('problem with request: ' + e.message);
+  });
+
+  req.write(param);
+  req.end();
+}
+
+function bootWindows(next) {
+  request({
+    path: '/api/iaas/windows-custom-server-127.0.0.1-windows-server-std-2012R2-amd64/start',
+    verb: 'POST'
+  }, function() {
+    if (next)
+      next()
+  });
+}
+
+function waitForWindowsToBeRunning(next) {
+  console.log("Wainting for Windows to be running....");
+  request({
+    path: '/api/iaas',
+    verb: 'GET',
+  }, function(res) {
+    if (res.data[0].attributes.status != "running") {
+      waitForWindowsToBeRunning();
+    }
+    else
+      if (next)
+        next();
+  });
+}
+
+function login(next) {
+  request({
+    path: '/oauth/token',
+    verb: 'POST',
+    param: {
+      username: "admin@nanocloud.com",
+      password: "admin",
+      grant_type: "password"
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': "Basic OTQwNWZiNmIwZTU5ZDI5OTdlM2M3NzdhMjJkOGYwZTYxN2E5ZjViMzZiNjU2NWM3NTc5ZTViZTZkZWI4ZjdhZTo5MDUwZDY3YzJiZTA5NDNmMmM2MzUwNzA1MmRkZWRiM2FlMzRhMzBlMzliYmJiZGFiMjQxYzkzZjhiNWNmMzQx"
+    }
+  }, function(res) {
+    TOKEN = res.access_token;
+    console.log("Got token : " + TOKEN);
+    if (next)
+      next();
+  });
+}
+
+function setHostInEnv() {
+  var command = 'sed -i "s/value\\": \\"127.0.0.1\\"/value\\": \\"$(docker exec proxy hostname -I | awk \'{print $1}\')\\"/g" api/NanoEnv.postman_environment'
+
+  console.log("Setting host in api file")
+  var returnedValue = proc.execSync(command);
+
+  console.log(returnedValue.toString());
+}
+
+function done() {
+  console.log('Ready to perform tests')
+}
+
+waitForNanocloudToBeOnline();
+setHost();
+
+async.waterfall([
+  setHostInEnv,
+  login,
+  bootWindows,
+  waitForWindowsToBeRunning,
+  done
+])
+

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,4 +1,25 @@
 #!/usr/bin/nodejs
+/*
+ * Nanocloud Community, a comprehensive platform to turn any application
+ * into a cloud solution.
+ *
+ * Copyright (C) 2015 Nanocloud Software
+ *
+ * This file is part of Nanocloud community.
+ *
+ * Nanocloud community is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud community is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 var http = require('https');
 var proc = require('child_process');

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -12,7 +12,7 @@ function request(options, callback) {
   var message = "";
   var status = null;
 
-  var headers = options.headers || {};
+  var headers = options.headers || {};
   var param = JSON.stringify(options.param) || "";
 
   if (TOKEN) {


### PR DESCRIPTION
Implement dedicate docker-compose-test.yml to run Nanocloud in test mode (no exposed ports)
Implement script to boot ad wait for Windows to be running in order to wait the proper amount of time before starting postman tests.
Allow to build a container to run newman.
