### PR TITLE
Use dynamically defined HOST, PORT and PROTOCOL when login in nanotest

### DIFF
--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -25,7 +25,7 @@ var nano = require('./nanotest');
 var expect = nano.expect;
 
 describe("nanocloud is Online", function() {
-  var request = nano.get('/').shouldReturn(200);
+  var request = nano.get('').shouldReturn(200);
 })
 
 var admin = nano.login({

--- a/tests/api/nanotest.js
+++ b/tests/api/nanotest.js
@@ -171,7 +171,7 @@ var nano = {
     return this._request().post(url, params, options);
   },
   login: function(credentials) {
-    var user = sync.request('https://localhost/oauth/token', {
+    var user = sync.request(nano.PROTOCOL + '://' + nano.HOST + ':' + nano.PORT + '/oauth/token', {
       method: 'POST',
       dataType: 'json',
       data: {


### PR DESCRIPTION
localhost was previously hardcoded
Avoid double slasj in URL when testing connectivity in index.
