### PR TITLE
Fix docker-compose file to adapt to docker-compose 1.6 name specifics

### DIFF
--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -19,6 +19,7 @@ services:
   image: nanocloud/nanocloud-backend
   volumes_from:
    - nanocloud-frontend
+   - nanocloud-canva
 
  nanocloud-canva:
   extends:

--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -20,6 +20,14 @@ services:
   volumes_from:
    - nanocloud-frontend
    - nanocloud-canva
+ nanocloud-frontend:
+  extends:
+   file: ./modules/docker-compose.yml
+   service: nanocloud-frontend
+  container_name: "nanocloud-frontend"
+  volumes:
+   - /opt/front
+  image: nanocloud/nanocloud-frontend:latest
 
  nanocloud-canva:
   extends:
@@ -38,15 +46,6 @@ services:
    - 80:80
    - 443:443
   image: nanocloud/proxy:indiana
-
- nanocloud-frontend:
-  extends:
-   file: ./modules/docker-compose.yml
-   service: nanocloud-backend
-  image: nanocloud/nanocloud-frontend
-  container_name: "nanocloud-frontend"
-  volumes:
-   - /opt/front
 
  iaas-module:
   extends:

--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -5,7 +5,7 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: guacamole-client
-  image: nanocloud/guacamole-client:indiana
+  image: nanocloud/guacamole-client
 
  guacamole-server:
   extends:
@@ -16,7 +16,7 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: nanocloud-backend
-  image: nanocloud/nanocloud-backend:indiana
+  image: nanocloud/nanocloud-backend
   volumes_from:
    - nanocloud-frontend
 
@@ -24,7 +24,7 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: nanocloud-canva
-  image: nanocloud/nanocloud-canva:indiana
+  image: nanocloud/nanocloud-canva
   container_name: "nanocloud-canva"
   volumes:
    - /opt/canva
@@ -42,7 +42,7 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: nanocloud-backend
-  image: nanocloud/nanocloud-frontend:indiana
+  image: nanocloud/nanocloud-frontend
   container_name: "nanocloud-frontend"
   volumes:
    - /opt/front
@@ -51,7 +51,7 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: iaas-module
-  image: nanocloud/iaas-module:indiana
+  image: nanocloud/iaas-module
 
  postgres:
   extends:

--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -45,7 +45,7 @@ services:
   ports:
    - 80:80
    - 443:443
-  image: nanocloud/proxy:indiana
+  image: nanocloud/proxy
 
  iaas-module:
   extends:

--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -16,10 +16,11 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: nanocloud-backend
-  image: nanocloud/nanocloud-backend
   volumes_from:
    - nanocloud-frontend
    - nanocloud-canva
+  image: nanocloud/nanocloud-backend
+
  nanocloud-frontend:
   extends:
    file: ./modules/docker-compose.yml
@@ -33,10 +34,10 @@ services:
   extends:
    file: ./modules/docker-compose.yml
    service: nanocloud-canva
-  image: nanocloud/nanocloud-canva
   container_name: "nanocloud-canva"
   volumes:
    - /opt/canva
+  image: nanocloud/nanocloud-canva
 
  proxy:
   extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
  nanocloud-frontend:
   extends:
    file: ./modules/docker-compose.yml
-   service: nanocloud-backend
+   service: nanocloud-frontend
   container_name: "nanocloud-frontend"
   volumes:
    - /opt/front

--- a/installation_dir/scripts/start.sh
+++ b/installation_dir/scripts/start.sh
@@ -38,8 +38,8 @@ fi
 if [ "${COMMUNITY_CHANNEL}" = "" ]; then
     COMMAND=${1}
 
-    if [ "${COMMAND}" = "indiana" ]; then
-	COMMUNITY_CHANNEL="indiana"
+    if [ "${COMMAND}" = "canary" ]; then
+	COMMUNITY_CHANNEL="canary"
     elif [ "${COMMAND}" = "dev" ]; then
 	COMMUNITY_CHANNEL="dev"
     else
@@ -61,8 +61,8 @@ if [ -f "${DOCKER_COMPOSE_BUILD_OUTPUT}" ]; then
     fi
 else
     echo "$(date "${DATE_FMT}") Starting nanocloud containers from docker hub $COMMUNITY_CHANNEL"
-    if [ "${COMMUNITY_CHANNEL}" = "indiana" ]; then
-	docker-compose --file "${ROOT_DIR}/docker-compose-indiana.yml" up -d
+    if [ "${COMMUNITY_CHANNEL}" = "canary" ]; then
+	docker-compose --file "${ROOT_DIR}/docker-compose-canary.yml" up -d
     else
 	docker-compose --file "${ROOT_DIR}/docker-compose.yml" up -d
     fi

--- a/installation_dir/scripts/stop.sh
+++ b/installation_dir/scripts/stop.sh
@@ -41,8 +41,8 @@ if [ -f "${DOCKER_COMPOSE_BUILD_OUTPUT}" ]; then
     docker-compose --file "${ROOT_DIR}/modules/docker-compose-build.yml" stop
 else
     echo "$(date "${DATE_FMT}") Stopping nanocloud containers from docker hub $COMMUNITY_CHANNEL"
-    if [ "${COMMUNITY_CHANNEL}" = "indiana" ]; then
-	docker-compose --file "${ROOT_DIR}/docker-compose-indiana.yml" stop
+    if [ "${COMMUNITY_CHANNEL}" = "canary" ]; then
+	docker-compose --file "${ROOT_DIR}/docker-compose-canary.yml" stop
     elif [ "${COMMUNITY_CHANNEL}" = "dev" ]; then
 	docker-compose --file "${ROOT_DIR}/modules/docker-compose-dev.yml" stop
     else

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -25,8 +25,8 @@ SCRIPT_UID=$(id -u)
 COMMUNITY_TAG="0.4.0"
 COMMAND=${1}
 
-if [ "${COMMAND}" = "indiana" ]; then
-    COMMUNITY_TAG="indiana"
+if [ "${COMMAND}" = "canary" ]; then
+    COMMUNITY_TAG="canary"
 fi
 
 if [ -z "$(which docker || true)" ]; then

--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -5,6 +5,8 @@ services:
   extends:
    file: ./docker-compose.yml
    service: guacamole-client
+  build: ./canva/guacamole-client
+  image: nanocloud/guacamole-client
 
  guacamole-server:
   extends:
@@ -15,38 +17,48 @@ services:
   extends:
    file: ./docker-compose.yml
    service: nanocloud-backend
+  build: ../nanocloud
   volumes_from:
    - nanocloud-frontend
    - nanocloud-canva
+  image: nanocloud/nanocloud-backend
    
  nanocloud-frontend:
+  build: ../webapp
   extends:
    file: ./docker-compose.yml
    service: nanocloud-frontend
   volumes:
    - /opt/front
   container_name: "nanocloud-frontend"
+  image: nanocloud/nanocloud-frontend
 
  nanocloud-canva:
   extends:
    file: ./docker-compose.yml
    service: nanocloud-canva
+  build: ./canva/frontend
   volumes:
    - /opt/canva
   container_name: "nanocloud-canva"
+  image: nanocloud/nanocloud-canva
 
  proxy:
   extends:
    file: ./docker-compose.yml
    service: proxy
+  build: ./nginx
   ports:
    - 80:80
    - 443:443
+  image: nanocloud/proxy
 
  iaas-module:
   extends:
    file: ./docker-compose.yml
    service: iaas-module
+  build: ./iaas
+  image: nanocloud/iaas-module
 
  postgres:
   extends:

--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -71,6 +71,7 @@ services:
   extends:
    file: ./docker-compose.yml
    service: proxy
+  build: ./nginx
   image: nanocloud/proxy:dev
   ports:
    - 80:80

--- a/modules/docker-compose-test.yml
+++ b/modules/docker-compose-test.yml
@@ -5,6 +5,7 @@ services:
   extends:
    file: ./docker-compose.yml
    service: guacamole-client
+  image: nanocloud/guacamole-client
 
  guacamole-server:
   extends:
@@ -18,6 +19,7 @@ services:
   volumes_from:
    - nanocloud-frontend
    - nanocloud-canva
+  image: nanocloud/nanocloud-backend
 
  nanocloud-frontend:
   extends:
@@ -26,6 +28,7 @@ services:
   volumes:
    - /opt/front
   container_name: "nanocloud-frontend"
+  image: nanocloud/nanocloud-frontend
 
  nanocloud-canva:
   extends:
@@ -34,11 +37,13 @@ services:
   volumes:
    - /opt/canva
   container_name: "nanocloud-canva"
+  image: nanocloud/nanocloud-canva
 
  proxy:
   extends:
    file: ./docker-compose.yml
    service: proxy
+  image: nanocloud/proxy
 
  postgres:
   extends:
@@ -49,6 +54,7 @@ services:
   extends:
    file: ./docker-compose.yml
    service: iaas-module
+  image: nanocloud/iaas-module
 
 networks:
  nanocloud:

--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -2,16 +2,12 @@ version: '2'
 
 services:
  guacamole-client:
-  image: nanocloud/guacamole-client
-  build: ./canva/guacamole-client
   restart: always
   container_name: "guacamole-client"
   networks:
    - nanocloud
 
  nanocloud-backend:
-  image: nanocloud/nanocloud-backend
-  build: ../nanocloud
   environment:
    - ENV=production
    - DATABASE_URI=postgres://nanocloud@postgres/nanocloud?sslmode=disable
@@ -46,8 +42,6 @@ services:
    - nanocloud
 
  nanocloud-canva:
-  image: nanocloud/nanocloud-canva
-  build: ./canva/frontend
   container_name: "nanocloud-canva"
   volumes:
    - /opt/canva
@@ -55,8 +49,6 @@ services:
    - nanocloud
 
  nanocloud-frontend:
-  image: nanocloud/nanocloud-frontend
-  build: ../webapp
   container_name: "nanocloud-webapp"
   volumes:
    - /opt/front
@@ -64,8 +56,6 @@ services:
    - nanocloud
 
  proxy:
-  build: ./nginx
-  image: nanocloud/proxy
   restart: always
   container_name: "proxy"
   networks:
@@ -82,8 +72,6 @@ services:
    - nanocloud
 
  iaas-module:
-  image: nanocloud/iaas-module
-  build: ./iaas
   environment:
    - ENV=production
    - AMQP_URI=amqp://guest:guest@rabbitmq:5672/

--- a/nanocloud.sh
+++ b/nanocloud.sh
@@ -30,8 +30,8 @@ DOCKER_COMPOSE_BUILD_OUTPUT="${CURRENT_DIR}/modules/build_output"
 
 COMMAND=${1}
 
-if [ "${COMMAND}" = "indiana" ]; then
-    COMMUNITY_CHANNEL="indiana"
+if [ "${COMMAND}" = "canary" ]; then
+    COMMUNITY_CHANNEL="canary"
 elif [ "${COMMAND}" = "dev" ]; then
     COMMUNITY_CHANNEL="dev"
 else


### PR DESCRIPTION
Following changes on Bamboo where Indiana releases have been renamed into canary.
Update docker-compose file to move definition of the origin from the parent file to the child file. This allows production docker-compose file to download images from the Docker Hub instead of using the built version defined in modules/docker-compose.yml
