### PR TITLE
Remove Nanocloud community container after use

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -73,5 +73,5 @@ case $COMMAND in
 esac
 
 # If no argument is provided then install Nanocloud
-docker run -e HOST_UID=$SCRIPT_UID -v ${PWD}/nanocloud:/var/lib/nanocloud nanocloud/community:${COMMUNITY_TAG}
+docker run -e HOST_UID=$SCRIPT_UID -v ${PWD}/nanocloud:/var/lib/nanocloud --rm nanocloud/community:${COMMUNITY_TAG}
 docker-compose -f ${PWD}/nanocloud/docker-compose.yml up -d


### PR DESCRIPTION
nanocloud/community container's only usage is to provide one-liner user with a working Nanocloud directory tree.
This container should removed itself after this job is done in order not to remain in background (revealed with docker ps -a)
