### PR TITLE
Fix could not mount : not a directory on gaucamole-client:dev

### DIFF
--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
    - 8000:8000
   volumes:
    - ./canva/guacamole-client/:/opt
-   - ./canva/guacamole-client/noauth-logged/target/guacamole-auth-noauthlogged-0.9.9.jar:/etc/guacamole/extensions/guacamole-auth-noauthlogged-0.9.9.jar
+   - ./canva/guacamole-client/noauth-logged/target/:/etc/guacamole/extensions/
 
  guacamole-server:
   extends:


### PR DESCRIPTION
Any attempt to mount guacamole-auth-noauthlogged.jar if it did no exist resulted in an error when running the container.
With this patch, the whole directory is mounted
