### PR TITLE
Clone labstack repo in http to avoid fingerprint checking

### DIFF
--- a/modules/iaas/Dockerfile
+++ b/modules/iaas/Dockerfile
@@ -13,7 +13,7 @@ COPY ./ /go/src/github.com/Nanocloud/community/modules/iaas
 
 WORKDIR /go/src/github.com/Nanocloud/community/modules/iaas
 
-RUN mkdir -p /go/src/github.com/labstack && git clone git@github.com:labstack/echo.git -b v1 /go/src/github.com/labstack/echo
+RUN mkdir -p /go/src/github.com/labstack && git clone https://github.com/labstack/echo.git -b v1 /go/src/github.com/labstack/echo
 RUN go get ./... && go build
 
 RUN mkdir -p /var/lib/nanocloud/downloads && mkdir -p /var/lib/nanocloud/images && mkdir -p /var/lib/nanocloud/pid


### PR DESCRIPTION
Same bug as fixed in #331 but it has has been forgotten to by applied on iaas-module's Dockerfile
