### PR TITLE
API doesn't not required JSON format nor client_secret to login

### DIFF
--- a/nanocloud/models/oauth/oauth.go
+++ b/nanocloud/models/oauth/oauth.go
@@ -86,9 +86,8 @@ func (c oauthConnector) GetClient(key string, secret string) (interface{}, error
 		`SELECT id, name,
 		key
 		FROM oauth_clients
-		WHERE key = $1::varchar
-		AND secret = $2::varchar`,
-		key, secret,
+		WHERE key = $1::varchar`,
+		key,
 	)
 	if err != nil {
 		return nil, err

--- a/webapp/app/authenticators/oauth2.js
+++ b/webapp/app/authenticators/oauth2.js
@@ -4,33 +4,5 @@ import Ember from 'ember';
 export default OAuth2PasswordGrant.extend({
   serverTokenEndpoint: 'oauth/token',
 
-  clientId: '9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae:9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341',
-
-  authenticate: function(username, password) {
-
-    return new Ember.RSVP.Promise((resolve, reject) => {
-
-      const serverTokenEndpoint = this.get('serverTokenEndpoint');
-      const options = {
-        url: serverTokenEndpoint,
-        data: JSON.stringify({
-          grant_type: 'password',
-          username: username,
-          password: password
-        }),
-        type: 'POST',
-        dataType: 'json',
-        contentType: 'application/json',
-        headers: {
-          Authorization: 'Basic ' + window.btoa(this.get('clientId'))
-        }
-      };
-
-      Ember.$.ajax(options).then(function (response) {
-          resolve(response);
-      }, function (xhr) {
-        reject(xhr.responseJSON || xhr.responseText);
-      });
-    });
-  }
+  clientId: '9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae'
 });


### PR DESCRIPTION
Credentials must be sent as HTTP form parameters
Nanocloud now accepts login with no client_secret provided.
This allows to use ember-simple-auth so we don't have to extend anything from it.
