### PR TITLE
Update installer.sh to be compatible with sh instead of requiring bash

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -31,7 +31,7 @@ if [ -z "$(which docker || true)" ]; then
   exit 2
 fi
 
-function check_docker_compose_file {
+check_docker_compose_file () {
     DOCKERCOMPOSEFILE=${PWD}/nanocloud/docker-compose.yml
 
     if [ -z "$(ls -l $DOCKERCOMPOSEFILE 2> /dev/null || true)" ]; then

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 #
 # Nanocloud Community, a comprehensive platform to turn any application
 # into a cloud solution.

--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -72,6 +72,8 @@ case $COMMAND in
         ;;
 esac
 
-# If no argument is provided then install Nanocloud
-docker run -e HOST_UID=$SCRIPT_UID -v ${PWD}/nanocloud:/var/lib/nanocloud --rm nanocloud/community:${COMMUNITY_TAG}
-docker-compose -f ${PWD}/nanocloud/docker-compose.yml up -d
+if [ -z "${COMMAND}" ]; then
+    # If no argument is provided then install Nanocloud
+    docker run -e HOST_UID=$SCRIPT_UID -v ${PWD}/nanocloud:/var/lib/nanocloud --rm nanocloud/community:${COMMUNITY_TAG}
+    docker-compose -f ${PWD}/nanocloud/docker-compose.yml up -d
+fi


### PR DESCRIPTION
Update check_docker_compose_file function to be compatible with sh
Only run installer if no argument were provided
Update shebang to use sh instead of bash
