### PR TITLE
Fix Nanocloud not up because proxy keeps restarting

### DIFF
--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -49,6 +49,8 @@ services:
    - 80:80
    - 443:443
   image: nanocloud/proxy
+  depends_on:
+   - nanocloud-backend
 
  iaas-module:
   extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
    - 80:80
    - 443:443
   image: nanocloud/proxy:0.5.0
+  depends_on:
+   - nanocloud-backend
 
  postgres:
   extends:

--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -54,6 +54,8 @@ services:
    - 80:80
    - 443:443
   image: nanocloud/proxy
+  depends_on:
+   - nanocloud-backend
 
  iaas-module:
   extends:

--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -78,6 +78,8 @@ services:
   ports:
    - 80:80
    - 443:443
+  depends_on:
+   - nanocloud-backend
 
  postgres:
   extends:

--- a/modules/docker-compose-test.yml
+++ b/modules/docker-compose-test.yml
@@ -46,6 +46,8 @@ services:
    file: ./docker-compose.yml
    service: proxy
   image: nanocloud/proxy
+  depends_on:
+   - nanocloud-backend
 
  postgres:
   extends:


### PR DESCRIPTION
Make proxy container dependent of nanocloud-backend container.
Proxy should start only if nanocloud-backend is available.
