### PR TITLE
Stop returning internal server error when SSH time out

### DIFF
--- a/nanocloud/vms/drivers/manual/machine.go
+++ b/nanocloud/vms/drivers/manual/machine.go
@@ -63,8 +63,8 @@ func (m *machine) Status() (vms.MachineStatus, error) {
 	)
 	response, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error("Failed to check windows' state", err, string(response))
-		return vms.StatusUnknown, err
+		log.Info("Failed to check windows' state", err, string(response))
+		return vms.StatusDown, nil
 	}
 	if strings.Contains(string(response), "Running") {
 		return vms.StatusUp, nil


### PR DESCRIPTION
When using manual IaaS and windows is not configured or not running, Internal Server Error were returned.
