### PR TITLE
use apps instead of applications in route transition

### DIFF
--- a/webapp/app/routes/protected/index.js
+++ b/webapp/app/routes/protected/index.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend({
     if (this.get('session.user.isAdmin')) {
       this.transitionTo('protected.machines');
     } else {
-      this.transitionTo('protected.applications');
+      this.transitionTo('protected.apps');
     }
   }
 });


### PR DESCRIPTION
route protected.applications has been replaced by protected.apps.
