### PR TITLE
Fix canva slow down in production mode because it try to download live reload script

### DIFF
--- a/modules/canva/frontend/Dockerfile
+++ b/modules/canva/frontend/Dockerfile
@@ -9,5 +9,4 @@ RUN npm install -g bower ember-cli && npm install
 RUN bower install --allow-root
 RUN ember build --environment="production"
 
-EXPOSE 8080
 VOLUME ["/opt/canva"]

--- a/modules/canva/frontend/Dockerfile
+++ b/modules/canva/frontend/Dockerfile
@@ -5,9 +5,9 @@ RUN mkdir -p /opt/canva
 WORKDIR /opt/canva
 COPY ./ /opt/canva/
 
-RUN npm install && npm install -g bower
+RUN npm install -g bower ember-cli && npm install
 RUN bower install --allow-root
-RUN npm run build
+RUN ember build --environment="production"
 
 EXPOSE 8080
 VOLUME ["/opt/canva"]

--- a/modules/canva/frontend/Dockerfile-dev
+++ b/modules/canva/frontend/Dockerfile-dev
@@ -6,4 +6,4 @@ RUN npm install -g ember-cli
 ENV EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL=https://localhost:4200/canva/
 ENV EMBER_CLI_INJECT_LIVE_RELOAD_PORT=49152
 
-CMD ember build --environment="development" && ember serve --live-reload-port 49152 --ssl true --ssl-key /opt/ssl/nginx.key --ssl-cert /opt/ssl/nginx.crt
+CMD npm install && bower install --allow-root && ember build --environment="development" && ember serve --live-reload-port 49152 --ssl true --ssl-key /opt/ssl/nginx.key --ssl-cert /opt/ssl/nginx.crt

--- a/modules/canva/frontend/Dockerfile-dev
+++ b/modules/canva/frontend/Dockerfile-dev
@@ -6,4 +6,4 @@ RUN npm install -g ember-cli
 ENV EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL=https://localhost:4200/canva/
 ENV EMBER_CLI_INJECT_LIVE_RELOAD_PORT=49152
 
-CMD npm install && bower install --allow-root && ember serve --live-reload-port 49152 --ssl true --ssl-key /opt/ssl/nginx.key --ssl-cert /opt/ssl/nginx.crt
+CMD ember build --environment="development" && ember serve --live-reload-port 49152 --ssl true --ssl-key /opt/ssl/nginx.key --ssl-cert /opt/ssl/nginx.crt

--- a/modules/canva/frontend/app/index.html
+++ b/modules/canva/frontend/app/index.html
@@ -9,7 +9,6 @@
 
     {{content-for "head"}}
 
-    <script src="https://localhost:49152/livereload.js?snipver=1"></script>
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/frontend.css">
 


### PR DESCRIPTION
nanocloud-canva is now build in production mode in any case and in development mode in dev mode.
This allows better performance (no map file), no live reload (solve the issue with the endless loading) and no debug log in the console.
