### PR TITLE
Fix Guacamole session not working in dev mode

### DIFF
--- a/modules/canva/guacamole-client/Dockerfile-dev
+++ b/modules/canva/guacamole-client/Dockerfile-dev
@@ -5,4 +5,4 @@ MAINTAINER \
 RUN apt-get -y install inotify-tools
 ENV JPDA_ADDRESS=8000
 
-CMD ["sh", "-c", "(catalina.sh jpda run &) ; while inotifywait -r -e modify -e moved_to ./src ; do mvn package && touch /usr/local/tomcat/webapps/guacamole.war ; done"]
+CMD ["sh", "-c", "mvn package && (catalina.sh jpda run &) ; while inotifywait -r -e modify -e moved_to ./src ; do mvn package && touch /usr/local/tomcat/webapps/guacamole.war ; done"]


### PR DESCRIPTION
noauthlogged.jar was expected but not automatically build in dev mode leading to a non working environment
