### PR TITLE
Added endpoints to list sessions and logoff a session

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
    service: nanocloud-backend
   volumes_from:
    - nanocloud-frontend
-   - nanocloud-canva
   image: nanocloud/nanocloud-backend:0.5.1
 
  nanocloud-frontend:
@@ -31,15 +30,6 @@ services:
   volumes:
    - /opt/front
   image: nanocloud/nanocloud-frontend:0.5.1
-
- nanocloud-canva:
-  extends:
-   file: ./modules/docker-compose.yml
-   service: nanocloud-canva
-  container_name: "nanocloud-canva"
-  volumes:
-   - /opt/canva
-  image: nanocloud/nanocloud-canva:0.5.1
 
  proxy:
   extends:

--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -22,7 +22,6 @@ services:
   build: ../nanocloud
   volumes_from:
    - nanocloud-frontend
-   - nanocloud-canva
   image: nanocloud/nanocloud-backend
 
  nanocloud-frontend:
@@ -34,16 +33,6 @@ services:
    - /opt/front
   container_name: "nanocloud-frontend"
   image: nanocloud/nanocloud-frontend
-
- nanocloud-canva:
-  extends:
-   file: ./docker-compose.yml
-   service: nanocloud-canva
-  build: ./canva/frontend
-  volumes:
-   - /opt/canva
-  container_name: "nanocloud-canva"
-  image: nanocloud/nanocloud-canva
 
  proxy:
   extends:

--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -31,7 +31,6 @@ services:
    dockerfile: Dockerfile-dev
   volumes_from:
    - nanocloud-frontend
-   - nanocloud-canva
   volumes:
    - ../nanocloud:/go/src/github.com/Nanocloud/community/nanocloud/
   image: nanocloud/nanocloud-backend:dev
@@ -54,24 +53,6 @@ services:
   restart: always
   container_name: "nanocloud-frontend"
   image: nanocloud/nanocloud-frontend:dev
-
- nanocloud-canva:
-  extends:
-   file: ./docker-compose.yml
-   service: nanocloud-canva
-  volumes:
-   - /opt/canva
-   - ./canva/frontend/:/opt/canva
-   - ./nginx/conf/certificates:/opt/ssl/:ro
-  build:
-   context: ./canva/frontend
-   dockerfile: Dockerfile-dev
-  image: nanocloud/nanocloud-canva:dev
-  ports:
-   - 49152:49152
-   - 4200:4200
-  restart: always
-  container_name: "nanocloud-canva"
 
  proxy:
   extends:

--- a/modules/docker-compose-test.yml
+++ b/modules/docker-compose-test.yml
@@ -20,7 +20,6 @@ services:
    service: nanocloud-backend
   volumes_from:
    - nanocloud-frontend
-   - nanocloud-canva
   image: nanocloud/nanocloud-backend
 
  nanocloud-frontend:
@@ -31,15 +30,6 @@ services:
    - /opt/front
   container_name: "nanocloud-frontend"
   image: nanocloud/nanocloud-frontend
-
- nanocloud-canva:
-  extends:
-   file: ./docker-compose.yml
-   service: nanocloud-canva
-  volumes:
-   - /opt/canva
-  container_name: "nanocloud-canva"
-  image: nanocloud/nanocloud-canva
 
  proxy:
   extends:

--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -44,13 +44,6 @@ services:
   networks:
    - nanocloud
 
- nanocloud-canva:
-  container_name: "nanocloud-canva"
-  volumes:
-   - /opt/canva
-  networks:
-   - nanocloud
-
  nanocloud-frontend:
   container_name: "nanocloud-webapp"
   volumes:

--- a/nanocloud/main.go
+++ b/nanocloud/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Nanocloud/community/nanocloud/routes/logout"
 	"github.com/Nanocloud/community/nanocloud/routes/machines"
 	"github.com/Nanocloud/community/nanocloud/routes/oauth"
+	"github.com/Nanocloud/community/nanocloud/routes/sessions"
 	"github.com/Nanocloud/community/nanocloud/routes/tokens"
 	"github.com/Nanocloud/community/nanocloud/routes/upload"
 	"github.com/Nanocloud/community/nanocloud/routes/users"
@@ -119,6 +120,13 @@ func main() {
 	e.Patch("/api/applications/:app_id", m.OAuth2(m.Admin(apps.ChangeAppName)))
 
 	go appsModel.CheckPublishedApps()
+
+	/**
+	 * SESSIONS
+	 */
+
+	e.Get("/api/sessions", m.OAuth2(sessions.List))
+	e.Delete("/api/sessions", m.OAuth2(sessions.Logoff))
 
 	/**
 	 * HISTORY

--- a/nanocloud/models/users/user.go
+++ b/nanocloud/models/users/user.go
@@ -8,5 +8,5 @@ type User struct {
 	FirstName       string `json:"first-name"`
 	LastName        string `json:"last-name"`
 	Sam             string `json:"sam"`
-	WindowsPassword string `json:"windows_password"`
+	WindowsPassword string `json:"windows-password"`
 }

--- a/nanocloud/routes/sessions/sessions.go
+++ b/nanocloud/routes/sessions/sessions.go
@@ -1,0 +1,89 @@
+package sessions
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/Nanocloud/community/nanocloud/models/users"
+	"github.com/Nanocloud/community/nanocloud/utils"
+	log "github.com/Sirupsen/logrus"
+	"github.com/labstack/echo"
+)
+
+var kServer string
+
+type hash map[string]interface{}
+
+func List(c *echo.Context) error {
+	user := c.Get("user").(*users.User)
+
+	resp, err := http.Get("http://" + kServer + ":9090/sessions/" + user.Sam)
+	if err != nil {
+		log.Error(err)
+		return c.JSON(http.StatusInternalServerError, hash{
+			"error": [1]hash{
+				hash{
+					"detail": err.Error(),
+				},
+			},
+		})
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+		return c.JSON(http.StatusInternalServerError, hash{
+			"error": [1]hash{
+				hash{
+					"detail": err.Error(),
+				},
+			},
+		})
+	}
+	return c.JSON(http.StatusOK, string(b))
+}
+
+func Logoff(c *echo.Context) error {
+	user := c.Get("user").(*users.User)
+
+	req, err := http.NewRequest("DELETE", "http://"+kServer+":9090/sessions/"+user.Sam, nil)
+	if err != nil {
+		log.Error(err)
+		return c.JSON(http.StatusInternalServerError, hash{
+			"error": [1]hash{
+				hash{
+					"detail": err.Error(),
+				},
+			},
+		})
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil || resp.Status != "200 OK" {
+		log.Error(err)
+		return c.JSON(http.StatusInternalServerError, hash{
+			"error": [1]hash{
+				hash{
+					"detail": resp.Status,
+				},
+			},
+		})
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+		return c.JSON(http.StatusInternalServerError, hash{
+			"error": [1]hash{
+				hash{
+					"detail": err.Error(),
+				},
+			},
+		})
+	}
+	return c.JSON(http.StatusOK, string(b))
+}
+
+func init() {
+	kServer = utils.Env("SERVER", "localhost")
+}

--- a/plaza/router/router.go
+++ b/plaza/router/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Nanocloud/community/plaza/routes/apps"
 	"github.com/Nanocloud/community/plaza/routes/files"
 	"github.com/Nanocloud/community/plaza/routes/power"
+	"github.com/Nanocloud/community/plaza/routes/sessions"
 	log "github.com/Sirupsen/logrus"
 	"github.com/labstack/echo"
 )
@@ -17,13 +18,29 @@ func Start() {
 	e := echo.New()
 
 	e.Get("/", about.Get)
+
+	/***
+	FILES
+	***/
+
 	e.Get("/files", files.Get)
 	e.Post("/upload", files.Post)
 	e.Get("/upload", files.GetUpload)
 
+	/***
+	POWER
+	***/
+
 	e.Get("/shutdown", power.ShutDown)
 	e.Get("/restart", power.Restart)
 	e.Get("/checkrds", power.CheckRDS)
+
+	/***
+	SESSIONS
+	***/
+
+	e.Get("/sessions/:id", sessions.Get)
+	e.Delete("/sessions/:id", sessions.Logoff)
 
 	/***
 	APPS

--- a/plaza/routes/sessions/sessions.go
+++ b/plaza/routes/sessions/sessions.go
@@ -34,6 +34,9 @@ func Get(c *echo.Context) error {
 		log.Error("Error while unmarshaling query response: ", err)
 	}
 	response := formatResponse(tab, c.Param("id"))
+	if len(response) == 0 {
+		response = make([][]string, 0)
+	}
 	return c.JSON(
 		http.StatusOK,
 		hash{

--- a/plaza/routes/sessions/sessions.go
+++ b/plaza/routes/sessions/sessions.go
@@ -1,0 +1,67 @@
+package sessions
+
+import (
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/labstack/echo"
+)
+
+type hash map[string]interface{}
+
+func formatResponse(tab []string, id string) [][]string {
+	var format [][]string
+	for _, val := range tab {
+		newtab := strings.Fields(val)
+		if len(newtab) == 4 {
+			if id == "Administrator" || newtab[1] == id {
+				format = append(format, newtab)
+			}
+		}
+	}
+	return format
+}
+
+func Get(c *echo.Context) error {
+	cmd := exec.Command("powershell.exe", "query session | ConvertTo-Json -Compress")
+	resp, err := cmd.CombinedOutput()
+	var tab []string
+	err = json.Unmarshal(resp, &tab)
+	if err != nil {
+		log.Error("Error while unmarshaling query response: ", err)
+	}
+	response := formatResponse(tab, c.Param("id"))
+	return c.JSON(
+		http.StatusOK,
+		hash{
+			"data": response,
+		},
+	)
+}
+
+func Logoff(c *echo.Context) error {
+	cmd := exec.Command("powershell.exe", "query session | ConvertTo-Json -Compress")
+	resp, err := cmd.CombinedOutput()
+	var tab []string
+	err = json.Unmarshal(resp, &tab)
+	if err != nil {
+		log.Error("Error while unmarshaling query response: ", err)
+	}
+	response := formatResponse(tab, c.Param("id"))
+	if len(response) == 1 {
+		cmd := exec.Command("powershell.exe", "logoff "+response[0][2])
+		resp, err = cmd.CombinedOutput()
+		if err != nil {
+			log.Error("Error while loging off user: ", err, string(resp))
+		}
+	}
+	return c.JSON(
+		http.StatusOK,
+		hash{
+			"data": response,
+		},
+	)
+}

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -35,3 +35,4 @@ var admin = nano.login({
 
 require('./test-login')();
 require('./test-users')(admin);
+require('./test-sessions')(admin);

--- a/tests/api/nanotest.js
+++ b/tests/api/nanotest.js
@@ -125,16 +125,12 @@ var nano = {
         var validator = new JSONAPIValidator();
         var valid = true;
 
-        var tmp = this.response.data;
         try {
-          validator.validate(tmp);
+          validator.validate(this.response.data);
         } catch (e) {
             valid = false;
         }
 
-/*        if (valid && !validator.isValid(this.response.data)) {
-          valid = false;
-        }*/
 
         it("should comply to JSON API schema", function() {
           expect(valid).to.equal(true);

--- a/tests/api/nanotest.js
+++ b/tests/api/nanotest.js
@@ -190,8 +190,7 @@ var nano = {
         grant_type: "password"
       },
       headers: {
-        Authorization: 'Basic ' + new Buffer(this.CLIENTID).toString('base64'),
-        'Content-Type': 'application/json'
+        Authorization: 'Basic ' + new Buffer(this.CLIENTID).toString('base64')
       }
     })
 

--- a/tests/api/test-login.js
+++ b/tests/api/test-login.js
@@ -74,8 +74,7 @@ module.exports = function() {
       grant_type: 'password'
     }, {
       headers: {
-        Authorization: 'Basic ' + new Buffer(nano.CLIENTID).toString('base64'),
-        'Content-Type': 'application/json'
+        Authorization: 'Basic ' + new Buffer(nano.CLIENTID).toString('base64')
       }
     }).shouldReturn(401)
         .shouldBeJSON()
@@ -98,7 +97,6 @@ module.exports = function() {
     }, {
       headers: {
         Authorization: 'Basic ' + new Buffer(nano.CLIENTID).toString('base64'),
-        'Content-Type': 'application/json'
       }
     }).shouldReturn(400)
         .shouldBeJSON()

--- a/tests/api/test-login.js
+++ b/tests/api/test-login.js
@@ -32,9 +32,10 @@ module.exports = function() {
       type: 'object',
       properties: {
         access_token: {type: 'string'},
-        type: {'type': 'string'}
+        token_type: {'type': 'string'},
+				expires_in: {type: 'integer'}
       },
-      required: ['access_token', 'type'],
+      required: ['access_token', 'token_type', 'expires_in'],
       additionalProperties: false
     };
 
@@ -44,15 +45,14 @@ module.exports = function() {
       grant_type: 'password'
     }, {
       headers: {
-        Authorization: 'Basic ' + new Buffer(nano.CLIENTID).toString('base64'),
-        'Content-Type': 'application/json'
+        Authorization: 'Basic ' + new Buffer(nano.CLIENTID).toString('base64')
       }
     }).shouldReturn(200)
         .shouldBeJSON()
         .shouldComplyToNotJsonAPI(expectedSchema);
 
     it('should issue Bearer tokens', function() {
-      expect(request.response.data.type).to.equal('Bearer')
+      expect(request.response.data.token_type).to.equal('Bearer')
     })
   });
 

--- a/tests/api/test-sessions.js
+++ b/tests/api/test-sessions.js
@@ -1,0 +1,41 @@
+#!/usr/bin/nodejs
+/*
+ * Nanocloud Community, a comprehensive platform to turn any application
+ * into a cloud solution.
+ *
+ * Copyright (C) 2015 Nanocloud Software
+ *
+ * This file is part of Nanocloud community.
+ *
+ * Nanocloud community is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud community is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var nano = require('./nanotest');
+var expect = nano.expect;
+
+module.exports = function(admin) {
+
+  describe("List sessions with no sessions", function() {
+
+
+    var request = nano.as(admin).get("api/sessions")
+    .shouldReturn(200)
+    .shouldBeJSONAPI();
+
+    it("shoud be an empty array", function() {
+      return expect(request.response.data.data).to.be.empty;
+    });
+
+  });
+};

--- a/tests/api/test-users.js
+++ b/tests/api/test-users.js
@@ -37,7 +37,7 @@ module.exports = function(admin) {
         first_name: {type: 'string'},
         last_name: {type: 'string'},
         sam: {type: 'string'},
-        windows_password: {type: 'string'},
+        'windows-password': {type: 'string'},
       },
       required: ['email', 'first_name', 'activated', 'is_admin', 'first_name', 'last_name', 'sam', 'windows_password'],
       additionalProperties: false
@@ -52,11 +52,11 @@ module.exports = function(admin) {
       return expect(request).to.comprise.of.json({
         email: 'admin@nanocloud.com',
         activated: true,
-        is_admin: true,
-        first_name: "John",
-        last_name: "Doe",
+        "is-admin": true,
+        "first-name": "Admin",
+        "last-name": "Nanocloud",
         sam: "Administrator",
-        windows_password: "Nanocloud123+"
+        "windows-password": "Nanocloud123+"
       });
     })
   })
@@ -68,8 +68,8 @@ module.exports = function(admin) {
       "data" : {
         "type": "user",
         "attributes": {
-          "first_name": nano.USER_FIRSTNAME,
-          "last_name": nano.USER_LASTNAME,
+          "first-name": nano.USER_FIRSTNAME,
+          "last-name": nano.USER_LASTNAME,
           "email": nano.USER_EMAIL,
           "password": nano.USER_PASSWORD
         }

--- a/tests/api/test-users.js
+++ b/tests/api/test-users.js
@@ -33,13 +33,13 @@ module.exports = function(admin) {
       properties: {
         email: {type: 'string'},
         activated: {type: 'boolean'},
-        is_admin: {type: 'boolean'},
-        first_name: {type: 'string'},
-        last_name: {type: 'string'},
+        'is-admin': {type: 'boolean'},
+        'first-name': {type: 'string'},
+        'last-name': {type: 'string'},
         sam: {type: 'string'},
         'windows-password': {type: 'string'},
       },
-      required: ['email', 'first_name', 'activated', 'is_admin', 'first_name', 'last_name', 'sam', 'windows_password'],
+      required: ['email', 'first-name', 'activated', 'is-admin', 'first-name', 'last-name', 'sam', 'windows-password'],
       additionalProperties: false
     };
 


### PR DESCRIPTION
Nanocloud and plaza now both have corresponding endpoints to list all active windows session for the admin, and the current one ( if there is one ) for a regular user. Additionally , the logoff endpoint will be used to logoff the user who sent the request from windows.  
