### PR TITLE
Fix start VM did not work in dev mode

### DIFF
--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -86,7 +86,6 @@ services:
   image: nanocloud/iaas-module:dev
   volumes:
    - ./iaas/:/go/src/github.com/Nanocloud/community/modules/iaas/
-   - ./iaas/scripts/:/var/lib/nanocloud/scripts
    - ../installation_dir/images:/var/lib/nanocloud/images
 
 networks:

--- a/modules/iaas/main.go
+++ b/modules/iaas/main.go
@@ -198,7 +198,12 @@ func main() {
 	conf.Password = env("PASSWORD", "ItsPass1942+")
 	conf.User = env("USER", "Administrator")
 	conf.instDir = os.Getenv("INSTALLATION_DIR")
-	conf.root = os.Getenv("PWD")
+
+	if os.Getenv("PWD") != "" {
+		conf.root = os.Getenv("PWD")
+	} else {
+		conf.root = path.Dir(os.Args[0])
+	}
 
 	if len(conf.instDir) == 0 {
 		conf.instDir = "/var/lib/nanocloud"

--- a/modules/iaas/main.go
+++ b/modules/iaas/main.go
@@ -198,7 +198,7 @@ func main() {
 	conf.Password = env("PASSWORD", "ItsPass1942+")
 	conf.User = env("USER", "Administrator")
 	conf.instDir = os.Getenv("INSTALLATION_DIR")
-	conf.root = path.Dir(os.Args[0])
+	conf.root = os.Getenv("PWD")
 
 	if len(conf.instDir) == 0 {
 		conf.instDir = "/var/lib/nanocloud"


### PR DESCRIPTION
Do not mount iaas/scripts in dev mode since it is copied (and mapped in dev mode) to /go/src/github.com/Nanocloud/community/module/iaas/script anyway
Use current working directory to determine where to find scripts. We previously rely on argv[0] which happened to be wrongly set in dev mode since fresh executes the binary from a tmp subdirectory.

In case PWD is not set, the code will rely on the current binary directory as expected.
