### PR TITLE
Upgrade ember-simple-auth to latest version to avoid deprecation message in dev mode

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,7 +38,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-modal-dialog": "0.8.3",
     "ember-resolver": "^2.0.3",
-    "ember-simple-auth": "1.0.1",
+    "ember-simple-auth": "1.1.0-beta.3",
     "ember-tether": "0.3.0",
     "ember-toastr": "1.4.0",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
Ember introduced a new deprecation fixed in ember-simple-auth in their latest version here : https://github.com/simplabs/ember-simple-auth/pull/894
