### PR TITLE
Allow to build plaza from a Docker container

### DIFF
--- a/plaza/Dockerfile
+++ b/plaza/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.6
+MAINTAINER \
+  Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
+
+COPY ./ /go/src/github.com/Nanocloud/community/plaza
+WORKDIR /go/src/github.com/Nanocloud/community/plaza
+
+RUN ./install.sh && ./build.sh
+CMD ["sleep", "30"]

--- a/plaza/build.sh
+++ b/plaza/build.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 
-export GOOS=windows
-export GOARCH=amd64
+COMMAND=${1}
 
-go build
+if [ "${COMMAND}" = "docker" ]; then
+    docker build -t nanocloud/plaza .
+    docker run -d --name plaza nanocloud/plaza
+    docker cp plaza:/go/src/github.com/Nanocloud/community/plaza/plaza.exe .
+    docker kill plaza
+    docker rm plaza
+    docker rmi nanocloud/plaza
+else
+    export GOOS=windows
+    export GOARCH=amd64
+
+    go build
+fi


### PR DESCRIPTION
Avoid dependencies issues while building plaza by provising a way to build the executable from a Docker container.

Usage: ./build.sh docker
