### PR TITLE
user input not caught after VDI is opened

### DIFF
--- a/webapp/app/components/remote-session/component.js
+++ b/webapp/app/components/remote-session/component.js
@@ -56,6 +56,9 @@ export default Ember.Component.extend({
 
 
       guac.connect();
+
+      this.get('remoteSession').openedGuacSession[this.get('connectionName')].keyboard = keyboard;
+
     });
   }.observes('connectionName').on('becameVisible'),
 

--- a/webapp/app/components/single-tab/component.js
+++ b/webapp/app/components/single-tab/component.js
@@ -7,6 +7,7 @@ export default Ember.Component.extend({
 
   actions: {
     toggleSingleTab() {
+      this.sendAction('onClose', this.get('connectionName'));
       this.toggleProperty('isVisible');
     }
   }

--- a/webapp/app/protected/apps/index/controller.js
+++ b/webapp/app/protected/apps/index/controller.js
@@ -5,6 +5,7 @@ export default Ember.Controller.extend({
   showFileExplorer: false,
   connectionName: null,
   store: Ember.inject.service('store'),
+  remoteSession: Ember.inject.service('remote-session'),
 
   applications: Ember.computed(function() {
     return this.get('model')
@@ -13,6 +14,11 @@ export default Ember.Controller.extend({
   }),
 
   actions: {
+
+    disconnectGuacamole(connectionName) {
+      this.get('remoteSession').disconnectSession(connectionName);
+    },
+
     publish() {
       this.store.createRecord('application', {});
     },

--- a/webapp/app/protected/apps/index/template.hbs
+++ b/webapp/app/protected/apps/index/template.hbs
@@ -26,7 +26,7 @@
   </div>
 </div>
 
-{{#single-tab isVisible=showSingleTab}}
+{{#single-tab isVisible=showSingleTab onClose="disconnectGuacamole" connectionName=connectionName}}
   {{remote-session connectionName=connectionName}}
 {{/single-tab}}
 

--- a/webapp/app/remote-session/service.js
+++ b/webapp/app/remote-session/service.js
@@ -8,6 +8,8 @@ export default Ember.Service.extend({
 
   guacamole: null,
 
+  openedGuacSession: {},
+
   guacToken: function() {
     return Ember.$.post(config.GUACAMOLE_URL + 'api/tokens', {
       access_token: this.get('session.access_token')
@@ -50,7 +52,15 @@ export default Ember.Service.extend({
         tunnel
       );
 
+      this.get('openedGuacSession')[name] = { guac : guacamole };
+
       return guacamole;
     });
+  },
+
+  disconnectSession(name) {
+      this.get('openedGuacSession')[name].keyboard.onkeydown = null;
+      this.get('openedGuacSession')[name].keyboard.onkeyup = null;
+      this.get('openedGuacSession')[name].guac.disconnect();
   }
 });


### PR DESCRIPTION
User input aren't being caught once the VDI has been opened.
Fixed by disconnecting client and setting keyboard event to null when single tab is closed
