### PR TITLE
Fix LDAP not working because the wrong port was given

### DIFF
--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -18,7 +18,7 @@ services:
    - IAAS=qemu
    - WIN_USER=Administrator
    - WIN_SERVER=iaas-module
-   - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@iaas-module:636
+   - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@iaas-module:6360
    - BASE=DC=intra,DC=localdomain,DC=com
    - LDAP_USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com
    - BIND_DN=CN=Administrator,DC=intra,DC=localdomain,DC=com


### PR DESCRIPTION
In a regular Nanocloud Community installation, qemu boots the Windows VM with port 6360 bound to 636
