### PR TITLE
Fix remaining test failure

### DIFF
--- a/tests/api/JSONAPIschema.json
+++ b/tests/api/JSONAPIschema.json
@@ -14,11 +14,18 @@
 
   "definitions": {
     "data": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/resource"
-      },
-      "uniqueItems": true
+      "oneOf": [
+        {
+          "$ref": "#/definitions/resource"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/resource"
+          },
+          "uniqueItems": true
+        }
+      ]
     },
     "resource": {
       "description": "\"Resource objects\" appear in a JSON API document to represent resources.",
@@ -44,4 +51,3 @@
     }
   }
 }
-

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -23,6 +23,7 @@
 // jshint mocha:true
 
 var nano = require('./nanotest');
+var expect = nano.expect;
 
 describe('nanocloud is Online', function() {
   nano.get('').shouldReturn(200);

--- a/tests/api/nanotest.js
+++ b/tests/api/nanotest.js
@@ -29,6 +29,7 @@ var sync = require('urllib-sync');
 var extend = require('extend-object');
 var plugins = require('./assertions/plugins');
 var JSONAPIValidator = require('jsonapi-validator').Validator;
+var clone = require('clone');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 extend(exports, plugins);
@@ -163,10 +164,10 @@ var nano = {
       },
       shouldComplyTo: function(schema) {
         var JSONAPIschema = require('./JSONAPIschema.json');
+        var clonedJSONAPIschema = clone(JSONAPIschema);
+        clonedJSONAPIschema.definitions.attributes = schema;
 
-        JSONAPIschema.definitions.attributes = schema;
-
-        return this.shouldComplyToNotJsonAPI(JSONAPIschema);
+        return this.shouldComplyToNotJsonAPI(clonedJSONAPIschema);
       }
     };
   },

--- a/tests/api/package.json
+++ b/tests/api/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "chai": "^3.5.0",
     "chai-subset": "^1.2.1",
+    "clone": "^1.0.2",
     "extend-object": "^1.0.0",
     "jsonapi-validator": "^1.0.1",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Fix Windows was reported offline all the time
Fix expected schema feature could only be used once due to a global variable overriding
Allow data field in a jsonAPI response to be either an array or an object
