### PR TITLE
Bootstrap js removed

### DIFF
--- a/webapp/ember-cli-build.js
+++ b/webapp/ember-cli-build.js
@@ -50,7 +50,5 @@ module.exports = function(defaults) {
     destDir: 'assets/fonts'
   });
 
-  app.import('bower_components/bootstrap/dist/js/bootstrap.js');
-
   return app.toTree();
 };


### PR DESCRIPTION
Bootstrap js lib isn't and shouldn't be used.
