### PR TITLE
ember-modal removed from single-tab component

### DIFF
--- a/webapp/app/components/single-tab/template.hbs
+++ b/webapp/app/components/single-tab/template.hbs
@@ -1,38 +1,34 @@
 {{#if isVisible}}
-  {{#modal-dialog containerClassNames="ember-modal-fullscreen"
-    attachment="" targetAttachment=""}}
-
-    {{#vdi-drag-n-drop as |uploadData|}}  
-      <div class="ember-modal-fullscreen">
-        <div class="remote-session-topbar">
-          <div class="left">
-            {{#if uploadData.progress}}
-              {{ topbar-item materialIcon="call_made" class="upload-state-enabled"}}
-              <span class="state">{{uploadData.progress}}%
-                {{ fa-icon "refresh" spin=true}}
-              </span>
-            {{else}}
-              {{ topbar-item materialIcon="call_made" class="upload-state-disabled" }}
-            {{/if}}
-            <span class="state">{{uploadData.state}}</span>
-            {{#if uploadData.progress}}
-              <span class="link icon_link" {{ action uploadData.stopUpload }}>Cancel</span>
-            {{/if}}
-          </div>
-          <div class="right">
-            {{ topbar-item 
-              clickable=true
-              class="go-back"
-              hover-enabled=true
-              materialIcon="home"
-              click="toggleSingleTab"
-            }}
-          </div>
+  {{#vdi-drag-n-drop as |uploadData|}}
+    <div class="single-tab-container">
+      <div class="remote-session-topbar">
+        <div class="left">
+          {{#if uploadData.progress}}
+            {{ topbar-item materialIcon="call_made" class="upload-state-enabled"}}
+            <span class="state">{{uploadData.progress}}%
+              {{ fa-icon "refresh" spin=true}}
+            </span>
+          {{else}}
+            {{ topbar-item materialIcon="call_made" class="upload-state-disabled" }}
+          {{/if}}
+          <span class="state">{{uploadData.state}}</span>
+          {{#if uploadData.progress}}
+            <span class="link icon_link" {{ action uploadData.stopUpload }}>Cancel</span>
+          {{/if}}
         </div>
-        <div class="canva-fullscreen">
-            {{yield}}
+        <div class="right">
+          {{ topbar-item
+            clickable=true
+            class="go-back"
+            hover-enabled=true
+            materialIcon="home"
+            click="toggleSingleTab"
+          }}
         </div>
       </div>
-    {{/vdi-drag-n-drop }}  
-  {{/modal-dialog}}
+      <div class="canva-fullscreen">
+          {{yield}}
+      </div>
+    </div>
+  {{/vdi-drag-n-drop }}
 {{/if}}

--- a/webapp/app/styles/app.scss
+++ b/webapp/app/styles/app.scss
@@ -1,7 +1,7 @@
 @import "variables";
 
 @import "ember-modal-dialog/ember-modal-structure";
-@import "ember-modal-dialog/ember-modal-appearance";
+
 @import "bower_components/bootstrap/scss/bootstrap";
 @import "font-awesome";
 

--- a/webapp/app/styles/single-tab.scss
+++ b/webapp/app/styles/single-tab.scss
@@ -1,8 +1,11 @@
-.ember-modal-fullscreen {
+.single-tab-container {
+  top: 0;
+  left: 0;
+  position: fixed;
   width: 100%;
   height: 100%;
-  border-radius: 0;
-  padding: 0;
+  z-index: 50;
+  background: #fff;
 }
 
 .remote-session-topbar {
@@ -27,7 +30,7 @@
     padding-top: 3px;
     margin: 0px 0px 0px 5px;
   }
-  
+
   .upload-state-enabled {
     color: $gray;
   }


### PR DESCRIPTION
ember-modal will be needed for dialog boxes. `ember-modal-dialog/ember-modal-appearance` must be excluded for style purpose.
