### PR TITLE
User inputs validation on user creation

### DIFF
--- a/webapp/app/components/nano-input/component.js
+++ b/webapp/app/components/nano-input/component.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  mode: null,
+  placeholder: "",
+  errorMessage: "",
+  value: "",
+  focus: false,
+  isValid: true,
+  type: "text",
+
+  init: function() {
+    this._super(...arguments);
+    var valuePath = this.get('valuePath');
+
+    if (this.get('model')) {
+      Ember.defineProperty(this, 'value', Ember.computed.alias(`model.${valuePath}`));
+    }
+  },
+
+  getErrorMessage: function() {
+
+    if (this.get('focus') === false && this.get('model')) {
+      if (this.get('value')) {
+        var errorMessage = this.get('model').get('validations.attrs').get(this.get('valuePath')).get('message');
+
+        this.set('errorMessage', errorMessage);
+        this.set('isValid', Ember.isEmpty(errorMessage));
+      }
+    }
+  }.observes('value', 'focus'),
+
+  actions: {
+    toggleFocus: function() {
+      this.toggleProperty('focus');
+    }
+  }
+});

--- a/webapp/app/components/nano-input/template.hbs
+++ b/webapp/app/components/nano-input/template.hbs
@@ -1,0 +1,7 @@
+<fieldset class="form-group {{ unless isValid "has-danger" }}">
+  {{input class='form-control' focus-in="toggleFocus" focus-out="toggleFocus" type=type placeholder=placeholder value=value}}
+
+  {{#unless isValid}}
+    {{errorMessage}}
+  {{/unless}}
+</fieldset>

--- a/webapp/app/protected/users/new/controller.js
+++ b/webapp/app/protected/users/new/controller.js
@@ -18,7 +18,7 @@ export default Ember.Controller.extend({
         .then(() => {
           this.transitionToRoute('protected.users');
       }, (errorMessage) => {
-        this.set('errorMessage', errorMessage);
+        this.toast.error('Cannot create new user : ' + errorMessage);
       });
     }
   }

--- a/webapp/app/protected/users/new/controller.js
+++ b/webapp/app/protected/users/new/controller.js
@@ -10,6 +10,10 @@ export default Ember.Controller.extend({
         this.toast.error('Password must match');
         return ;
       }
+      if (!this.model.validate()) {
+        return this.toast.error('Cannot create user');
+      }
+
       this.model.save()
         .then(() => {
           this.transitionToRoute('protected.users');

--- a/webapp/app/protected/users/new/controller.js
+++ b/webapp/app/protected/users/new/controller.js
@@ -7,7 +7,7 @@ export default Ember.Controller.extend({
   actions: {
     add() {
       if (this.get('model.password') !== this.get('passwordConfirmation')) {
-        this.set('errorMessage', "Password must match");
+        this.toast.error('Password must match');
         return ;
       }
       this.model.save()

--- a/webapp/app/protected/users/new/template.hbs
+++ b/webapp/app/protected/users/new/template.hbs
@@ -6,26 +6,13 @@
  </h4>
   <div class="content-wrapper form">
     <form {{action 'add' on='submit'}}>
-      <fieldset class="form-group">
-        {{input class='form-control' placeholder='Firstname' value=model.firstName}}
-      </fieldset>
-      <fieldset class="form-group">
-        {{input class='form-control' placeholder='Lastname' value=model.lastName}}
-      </fieldset>
-      <fieldset class="form-group">
-        {{input class='form-control' placeholder='Email address' value=model.email}}
-      </fieldset>
-      <fieldset class="form-group">
-        {{input class='form-control' placeholder='Password' type='password' value=model.password}}
-      </fieldset>
-      <fieldset class="form-group">
-        {{input class='form-control' placeholder='Password confirmation' type='password' value=passwordConfirmation}}
-      </fieldset>
-      <button type="submit" class="btn btn-primary btn-block text-uppercase">Create</button>
-    </form>
+        {{nano-input placeholder='Firstname' model=model valuePath="firstName"}}
+        {{nano-input placeholder='Lastname' model=model valuePath="lastName"}}
+        {{nano-input placeholder='Email address' model=model valuePath="email"}}
+        {{nano-input placeholder='Password' type="password" model=model valuePath="password"}}
+        {{nano-input placeholder='Password confirmation' type="password" value=passwordConfirmation}}
 
-    {{#if errorMessage}}
-      <p>{{errorMessage}}</p>
-    {{/if}}
+        <button type="submit" class="btn btn-primary btn-block text-uppercase">Create</button>
+    </form>
   </div>
 </div>

--- a/webapp/app/user/model.js
+++ b/webapp/app/user/model.js
@@ -1,6 +1,23 @@
 import DS from 'ember-data';
+import {validator, buildValidations} from 'ember-cp-validations';
 
-export default DS.Model.extend({
+const Validations = buildValidations({
+  firstName: validator('presence', true),
+  lastName: validator('presence', true),
+  password: [
+    validator('presence', true),
+    validator('length', {
+      min: 8,
+      max: 255
+    })
+  ],
+  email: [
+    validator('presence', true),
+    validator('format', { type: 'email' })
+  ]
+});
+
+export default DS.Model.extend(Validations, {
   email: DS.attr('string'),
   activated: DS.attr('boolean'),
   isAdmin: DS.attr('boolean'),

--- a/webapp/app/user/model.js
+++ b/webapp/app/user/model.js
@@ -2,8 +2,20 @@ import DS from 'ember-data';
 import {validator, buildValidations} from 'ember-cp-validations';
 
 const Validations = buildValidations({
-  firstName: validator('presence', true),
-  lastName: validator('presence', true),
+  firstName: [
+    validator('presence', true),
+    validator('length', {
+      min: 2,
+      max: 255
+    })
+  ],
+  lastName: [
+    validator('presence', true),
+    validator('length', {
+      min: 2,
+      max: 255
+    })
+  ],
   password: [
     validator('presence', true),
     validator('length', {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,6 +33,7 @@
     "ember-cli-sass": "5.3.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cp-validations": "2.6.1",
     "ember-data": "^2.4.2",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",

--- a/webapp/tests/integration/components/nano-input/component-test.js
+++ b/webapp/tests/integration/components/nano-input/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('nano-input', 'Integration | Component | nano input', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{nano-input}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#nano-input}}
+      template block text
+    {{/nano-input}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Toast a message if password mismatch
Add validation for user model with ember-cp-validations
Implement nano-input to manage input with validations
Refactor protected/user/new template with nano-inputs  
Prevent from saving user if validation fails
Toast a message if user saving failed
Set firstname and lastname to be comprise between 2 and 254 characters
