### PR TITLE
Restore security nla parameter when logging into Windows

### DIFF
--- a/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
+++ b/modules/canva/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/user/UserContext.java
@@ -189,7 +189,7 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 			config.setParameter("port", connection.getJSONObject("attributes").getString("port"));
 			config.setParameter("username", connection.getJSONObject("attributes").getString("username"));
 			config.setParameter("password", connection.getJSONObject("attributes").getString("password"));
-			// config.setParameter("security", "nla");
+			config.setParameter("security", "nla");
 			config.setParameter("ignore-cert", "true");
 			config.setParameter("enable-printing", "true");
 			if (connection.getJSONObject("attributes").has("remote_app")) {


### PR DESCRIPTION
NLA parameter was wrongly commented and should be used for any connections.
