### PR TITLE
Add options to qemu to get a better user experience with VNC

### DIFF
--- a/modules/iaas/iaas.go
+++ b/modules/iaas/iaas.go
@@ -362,6 +362,7 @@ func bootWindows() error {
 		"-smp", "4",
 		"-vnc", ":2",
 		"-device", "virtio-net,netdev=user.0",
+		"-usb", "-device", "usb-tablet",
 		"-boot", "once=d",
 		"-machine", "type=pc,accel=kvm",
 		"-drive", "file="+conf.instDir+"/downloads/autoplaza.iso"+",index=0,media=cdrom",


### PR DESCRIPTION
Allow synchronization between local mouse and mouse on virtual machines.
