### PR TITLE
Fix progress bar does not get updated when downloading the Windows

### DIFF
--- a/webapp/app/components/machine-item/template.hbs
+++ b/webapp/app/components/machine-item/template.hbs
@@ -8,7 +8,7 @@
     {{machine.name}}
   </span>
   {{#if machine.isDownloading}}
-    <progress class="progress machine-progress" value="{{machine.progress}}" max="{{machine.progress}}">{{machine.progress}}%</progress>
+    <progress class="progress machine-progress" value="{{machine.progress}}" max="100">{{machine.progress}}%</progress>
   {{/if}}
 </div>
 {{/link-to}}


### PR DESCRIPTION
Fixes https://github.com/Nanocloud/community/issues/442

max value was set to the current value, leading for the vlaue always evaluated to 100%
