### PR TITLE
Fix crash when listing files if Windows is not yet running

### DIFF
--- a/nanocloud/errors/errors.go
+++ b/nanocloud/errors/errors.go
@@ -60,4 +60,11 @@ var (
 		http.StatusBadRequest,
 		"The request is not valid.",
 	}
+
+	WindowsNotOnline = &apiError{
+		0x000007,
+		http.StatusServiceUnavailable,
+		"Windows is not available.",
+	}
+
 )

--- a/nanocloud/routes/files/files.go
+++ b/nanocloud/routes/files/files.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"fmt"
+	apiErrors "github.com/Nanocloud/community/nanocloud/errors"
 	"github.com/Nanocloud/community/nanocloud/connectors/db"
 	"github.com/Nanocloud/community/nanocloud/models/users"
 	"github.com/Nanocloud/community/nanocloud/oauth2"
@@ -253,8 +254,7 @@ func Get(c *echo.Context) error {
 	resp, err := http.Get("http://" + kExecutionServer + ":9090/files?create=true&path=" + url.QueryEscape(path))
 	if err != nil {
 		log.Error(err)
-
-		return errors.New("Unable to contact the server")
+		return apiErrors.WindowsNotOnline.Detail(err.Error())
 	}
 
 	if resp.StatusCode == http.StatusNotFound {

--- a/webapp/app/protected/files/index/route.js
+++ b/webapp/app/protected/files/index/route.js
@@ -10,6 +10,7 @@ export default Ember.Route.extend({
       .catch((err) => {
         if (err.errors.length === 1 && err.errors[0].code === "000007") {
           this.toast.warning("Cannot list files because Windows is not running");
+          this.transitionTo('protected.files.nowindows');
         } else {
           return this.send("error", err);
         }

--- a/webapp/app/protected/files/index/route.js
+++ b/webapp/app/protected/files/index/route.js
@@ -6,6 +6,13 @@ export default Ember.Route.extend({
   },
 
   model() {
-    return this.get('store').query('file', { filename: './' });
+    return this.get('store').query('file', { filename: './' })
+      .catch((err) => {
+        if (err.errors.length === 1 && err.errors[0].code === "000007") {
+          this.toast.info("Cannot list files because Windows is not running");
+        } else {
+          return this.send("error", err);
+        }
+      });
   }
 });

--- a/webapp/app/protected/files/index/route.js
+++ b/webapp/app/protected/files/index/route.js
@@ -9,7 +9,7 @@ export default Ember.Route.extend({
     return this.get('store').query('file', { filename: './' })
       .catch((err) => {
         if (err.errors.length === 1 && err.errors[0].code === "000007") {
-          this.toast.info("Cannot list files because Windows is not running");
+          this.toast.warning("Cannot list files because Windows is not running");
         } else {
           return this.send("error", err);
         }

--- a/webapp/app/protected/files/index/template.hbs
+++ b/webapp/app/protected/files/index/template.hbs
@@ -3,16 +3,15 @@
   <div class='content-wrapper'>
     <table class="table application-table">
       <tbody>
-        {{#each items as |file|}}
-          {{#unless file.isDir}}
-            {{ file-item file=file download="downloadFile" }}
-          {{/unless}}
-        {{else}}
-          No files available.
-        {{/each}}
+      {{#each items as |file|}}
+        {{#unless file.isDir}}
+          {{ file-item file=file download="downloadFile" }}
+        {{/unless}}
+      {{else}}
+        No files available.
+      {{/each}}
       </tbody>
     </table>
     <div class="clearfix"></div>
   </div>
 </div>
-

--- a/webapp/app/protected/files/nowindows/route.js
+++ b/webapp/app/protected/files/nowindows/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/webapp/app/protected/files/nowindows/template.hbs
+++ b/webapp/app/protected/files/nowindows/template.hbs
@@ -1,0 +1,15 @@
+<div class="section p-a-2">
+  <h4>Files</h4>
+  <div class='content-wrapper'>
+    <div class="alert alert-info" role="alert">
+      <strong>Windows needs to be up to access files</strong>
+      <br />
+      Click "Go to machines" to be redirected to the page were you will be able to download then run the Windows execution machine
+    </div>
+    {{#link-to "protected.machines"}}
+      <button class='btn btn-primary btn-block'>
+        Go to machines
+      </button>
+    {{/link-to}}
+  </div>
+</div>

--- a/webapp/app/router.js
+++ b/webapp/app/router.js
@@ -18,7 +18,9 @@ Router.map(function() {
     this.route('apps', function() {
       this.route('app', { path: '/:app_id' });
     });
-    this.route('files', function() {});
+    this.route('files', function() {
+      this.route('nowindows');
+    });
   });
 
   this.route('login');

--- a/webapp/tests/unit/protected/files/nowindows/route-test.js
+++ b/webapp/tests/unit/protected/files/nowindows/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:protected/files/nowindows', 'Unit | Route | protected/files/nowindows', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Fix https://github.com/Nanocloud/community/issues/443

API returns StatusServiceUnavailable if Windows is not availalbe for [GET] api/files
Redirect to an information message if Windows needs to be boot up.
