### PR TITLE
Input validations on all fields

### DIFF
--- a/webapp/app/application/model.js
+++ b/webapp/app/application/model.js
@@ -1,6 +1,17 @@
 import DS from 'ember-data';
+import {validator, buildValidations} from 'ember-cp-validations';
 
-export default DS.Model.extend({
+const Validations = buildValidations({
+  displayName: [
+    validator('presence', true),
+    validator('length', {
+      min: 2,
+      max: 255
+    })
+  ]
+});
+
+export default DS.Model.extend(Validations, {
   alias: DS.attr('string'),
   collectionName: DS.attr('string'),
   displayName: DS.attr('string'),

--- a/webapp/app/components/app-item/component.js
+++ b/webapp/app/components/app-item/component.js
@@ -27,7 +27,8 @@ export default Ember.Component.extend({
             model, validations
           }) => {
             if (validations.get('isInvalid')) {
-              return this.toast.error('Cannot change application name');
+              this.toast.error('Cannot change application name');
+              return defer.reject(this.get('application.validations.attrs.displayName.messages'));
             }
 
             this.application.save()

--- a/webapp/app/components/app-item/component.js
+++ b/webapp/app/components/app-item/component.js
@@ -21,14 +21,29 @@ export default Ember.Component.extend({
         this.toggleProperty('isEditing');
       },
 
-      submitEditName() {
-        this.toggleProperty('isEditing');
-        this.application.save()
-          .then(() => {
-            this.toast.success("Application has been renamed successfully");
+      submitEditName(defer) {
+        this.get('application').validate()
+          .then(({
+            model, validations
+          }) => {
+            if (validations.get('isInvalid')) {
+              return this.toast.error('Cannot change application name');
+            }
+
+            this.application.save()
+              .then(() => {
+                this.toggleProperty('isEditing');
+                this.toast.success("Application has been renamed successfully");
+                defer.resolve();
+              })
+              .catch(() => {
+                this.toast.error("Application hasn't been renamed");
+                defer.reject();
+              });
           })
           .catch(() => {
-            this.toast.error("Application hasn't been renamed");
+            this.toast.error("Unknown error while rename application");
+            defer.reject();
           });
       },
 

--- a/webapp/app/components/app-item/component.js
+++ b/webapp/app/components/app-item/component.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
     session: Ember.inject.service('session'),
     unpublishState: false,
     isUnpublished: false,
- 
+
     actions : {
 
       toggleSingleTab(connectionName) {

--- a/webapp/app/components/app-item/template.hbs
+++ b/webapp/app/components/app-item/template.hbs
@@ -11,7 +11,7 @@
     {{#if session.user.isAdmin}}
       {{#edit-text
         textInput=application.displayName
-        action="submitEditName" }}
+        onClose="submitEditName" }}
         <span class='link' {{ action "toggleSingleTab" application.alias }}>{{application.displayName}}</span>
       {{/edit-text}}
     {{else}}

--- a/webapp/app/components/edit-text/component.js
+++ b/webapp/app/components/edit-text/component.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
 
       submit() {
         this.toggleProperty('isEditing');
-        this.sendAction();
+        this.sendAction('onClose', defer);
       },
 
       cancel() {

--- a/webapp/app/components/edit-text/component.js
+++ b/webapp/app/components/edit-text/component.js
@@ -4,6 +4,7 @@ export default Ember.Component.extend({
 
     originalValue: "",
     isEditing: false,
+    errorMessage: null,
 
     getInputType: function() {
       if (this.get('hideInput')) {
@@ -14,11 +15,16 @@ export default Ember.Component.extend({
       }
     }.property('hideInput'),
 
+    isValid: function() {
+      return this.get('errorMessage');
+    },
+
     actions: {
 
       toggle() {
         if (this.get('isEditing')) {
           this.set('textInput', this.get('originalValue'));
+          this.set('errorMessage', "");
         }
 
         this.toggleProperty('isEditing');
@@ -30,6 +36,8 @@ export default Ember.Component.extend({
         defer.promise.then(() => {
           this.set('originalValue', this.get('textInput'));
           this.send('toggle');
+        }, (err) => {
+          this.set('errorMessage', err);
         });
 
         this.sendAction('onClose', defer);

--- a/webapp/app/components/edit-text/component.js
+++ b/webapp/app/components/edit-text/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
+    originalValue: "",
     isEditing: false,
 
     getInputType: function() {
@@ -16,16 +17,26 @@ export default Ember.Component.extend({
     actions: {
 
       toggle() {
+        if (this.get('isEditing')) {
+          this.set('textInput', this.get('originalValue'));
+        }
+
         this.toggleProperty('isEditing');
       },
 
       submit() {
-        this.toggleProperty('isEditing');
+        var defer = Ember.RSVP.defer();
+
+        defer.promise.then(() => {
+          this.set('originalValue', this.get('textInput'));
+          this.send('toggle');
+        });
+
         this.sendAction('onClose', defer);
       },
 
       cancel() {
-        this.set('isEditing', false);
+        this.send('toggle');
       },
     }
 });

--- a/webapp/app/components/edit-text/template.hbs
+++ b/webapp/app/components/edit-text/template.hbs
@@ -12,6 +12,7 @@
           <i class="material-icons">clear</i>
         </span>
       </div>
+      {{errorMessage}}
   {{else}}
     <span class="content">
     {{ yield }}

--- a/webapp/app/components/edit-text/template.hbs
+++ b/webapp/app/components/edit-text/template.hbs
@@ -1,5 +1,6 @@
 <div class='editText'>
   {{#if isEditing }}
+    <form {{action "submit" on='submit'}}>
       {{input class='edit-input-text' type=getInputType value=textInput placeholder=textInputPlaceholder}}
       {{#if confirmation}}
         {{input class='edit-input-text' type=getInputType value=confirmInput placeholder=confirmInputPlaceholder}}
@@ -13,6 +14,7 @@
         </span>
       </div>
       {{errorMessage}}
+    </form>
   {{else}}
     <span class="content">
     {{ yield }}


### PR DESCRIPTION
Using ember-cp-validations. Validates user inputs on password and application's name.
Submit new application's name if enter is pressed.
