### PR TITLE
Fix history not working

### DIFF
--- a/modules/canva/guacamole-client/guac_home/guacamole.properties
+++ b/modules/canva/guacamole-client/guac_home/guacamole.properties
@@ -6,4 +6,4 @@ noauth-config: /etc/guacamole/noauth-config.xml
 
 noauthlogged-server-url: nanocloud-api
 noauthlogged-server-port: 8080
-noauthlogged-server-endpoint: api/history
+noauthlogged-server-endpoint: api/histories


### PR DESCRIPTION
guacamole.properties still hold previous endpoint name to log history
