### PR TITLE
Fix bug input got empty if edition was canceled right away

### DIFF
--- a/webapp/app/components/edit-text/component.js
+++ b/webapp/app/components/edit-text/component.js
@@ -27,6 +27,10 @@ export default Ember.Component.extend({
       }
     }.observes('isEditing'),
 
+    setOriginalValue: function() {
+      this.set('originalValue', this.get('textInput'));
+    }.on('init'),
+
     actions: {
 
       toggle() {


### PR DESCRIPTION
Fix bug leading to empty input if canceled button was click right after page was loaded and edit button was clicked
