### PR TITLE
Changed manual driver to use database instead of env variables

### DIFF
--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -16,7 +16,7 @@ services:
    - WIN_PASSWORD=Nanocloud123+
    - IAAS=qemu
    - WIN_USER=Administrator
-   - PLAZA=iaas-module
+   - PLAZA_ADDRESS=iaas-module
    - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@iaas-module:6360
    - BASE=DC=intra,DC=localdomain,DC=com
    - LDAP_USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com

--- a/modules/docker-compose.yml
+++ b/modules/docker-compose.yml
@@ -16,7 +16,7 @@ services:
    - WIN_PASSWORD=Nanocloud123+
    - IAAS=qemu
    - WIN_USER=Administrator
-   - WIN_SERVER=iaas-module
+   - PLAZA=iaas-module
    - LDAP_SERVER_URI=ldaps://Administrator:Nanocloud123+@iaas-module:6360
    - BASE=DC=intra,DC=localdomain,DC=com
    - LDAP_USERNAME=CN=Administrator,CN=Users,DC=intra,DC=localdomain,DC=com

--- a/nanocloud/connectors/vms/vms.go
+++ b/nanocloud/connectors/vms/vms.go
@@ -49,6 +49,6 @@ func Machine(id string) (vms.Machine, error) {
 	return (*vm).Machine(id)
 }
 
-func Create(name, password string, t vms.MachineType) (vms.Machine, error) {
-	return (*vm).Create(name, password, t)
+func Create(attr vms.MachineAttributes) (vms.Machine, error) {
+	return (*vm).Create(attr)
 }

--- a/nanocloud/main.go
+++ b/nanocloud/main.go
@@ -69,11 +69,10 @@ func initVms() error {
 		m["ad"] = os.Getenv("WIN_SERVER")
 
 	case "manual":
-		m["ad"] = os.Getenv("WIN_SERVER")
-		m["servers"] = os.Getenv("EXECUTION_SERVERS")
-		m["sshport"] = os.Getenv("SSH_PORT")
-		m["password"] = os.Getenv("WIN_PASSWORD")
-		m["user"] = os.Getenv("WIN_USER")
+		/* env variables are now used in migration. The following variables must be set:
+		- EXECUTION_SERVERS
+		- WIN_PASSWORD
+		- WIN_USER */
 	}
 
 	vm, err := vms.Open(iaas, m)

--- a/nanocloud/migration/machines/machines.go
+++ b/nanocloud/migration/machines/machines.go
@@ -51,7 +51,6 @@ func Migrate() error {
 		`CREATE TABLE machines (
 			id         varchar(60),
 			type       varchar(36),
-			ad         varchar(255),
 			ip         varchar(255),
 			plazaport  varchar(4) NOT NULL DEFAULT '9090',
 			username   varchar(36),
@@ -69,9 +68,9 @@ func Migrate() error {
 		ips := strings.Split(servers, ";")
 		for _, val := range ips {
 			rows, err := db.Query(`INSERT INTO machines
-			(id, type, ad, ip, username, password)
-			VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar, $6::varchar)`,
-				uuid.NewV4().String(), "manual", val, val, user, password)
+			(id, type, ip, username, password)
+			VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar)`,
+				uuid.NewV4().String(), "manual", val, user, password)
 
 			if err != nil {
 				return err

--- a/nanocloud/migration/machines/machines.go
+++ b/nanocloud/migration/machines/machines.go
@@ -46,10 +46,9 @@ func Migrate() error {
 	rows, err = db.Query(
 		`CREATE TABLE machines (
 			id         varchar(60),
-			role       varchar(36) NOT NULL DEFAULT 'ad',
 			type       varchar(36),
 			ad         varchar(255),
-			execserver varchar(255),
+			ip         varchar(255),
 			plazaport  varchar(4) NOT NULL DEFAULT '9090',
 			username   varchar(36),
 			password   varchar(60)

--- a/nanocloud/migration/machines/machines.go
+++ b/nanocloud/migration/machines/machines.go
@@ -47,10 +47,16 @@ func Migrate() error {
 		return nil
 	}
 
+	_, err = db.Exec(`CREATE TYPE vmtype AS ENUM('qemu', 'manual', 'aws', 'vmware', 'azure')`)
+	if err != nil {
+		log.Error(err.Error())
+		return err
+	}
+
 	rows, err = db.Query(
 		`CREATE TABLE machines (
 			id         varchar(60),
-			type       varchar(36),
+			type       vmtype,
 			ip         varchar(255),
 			plazaport  varchar(4) NOT NULL DEFAULT '9090',
 			username   varchar(36),
@@ -69,7 +75,7 @@ func Migrate() error {
 		for _, val := range ips {
 			rows, err := db.Query(`INSERT INTO machines
 			(id, type, ip, username, password)
-			VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar)`,
+			VALUES( $1::varchar, $2::vmtype, $3::varchar, $4::varchar, $5::varchar)`,
 				uuid.NewV4().String(), "manual", val, user, password)
 
 			if err != nil {

--- a/nanocloud/routes/machines/machines.go
+++ b/nanocloud/routes/machines/machines.go
@@ -41,6 +41,7 @@ type machine struct {
 	Ip            string `json:"ip"`
 	Type          string `json:"type"`
 	Status        string `json:"status"`
+	UserName      string `json:"username"`
 	AdminPassword string `json:"admin-password,omitempty"`
 	Platform      string `json:"platform"`
 	Progress      int    `json:"progress"`
@@ -215,7 +216,13 @@ func CreateMachine(c *echo.Context) error {
 		return err
 	}
 
-	m, err := vms.Create(rt.Name, rt.AdminPassword, nil)
+	attr := vm.MachineAttributes{
+		Type:     nil,
+		Username: rt.UserName,
+		Password: rt.AdminPassword,
+		Ip:       rt.Ip,
+	}
+	m, err := vms.Create(attr)
 	if err != nil {
 		log.Error(err)
 		return errors.UnableToCreateTheMachine
@@ -223,8 +230,7 @@ func CreateMachine(c *echo.Context) error {
 
 	rt, err = getSerializableMachine(m.Id())
 	if err != nil {
-		log.Error(err)
-		return errors.UnableToCreateTheMachine
+		return err
 	}
 
 	return utils.JSON(c, http.StatusOK, rt)

--- a/nanocloud/routes/machines/machines.go
+++ b/nanocloud/routes/machines/machines.go
@@ -218,6 +218,7 @@ func CreateMachine(c *echo.Context) error {
 
 	attr := vm.MachineAttributes{
 		Type:     nil,
+		Name:     rt.Name,
 		Username: rt.UserName,
 		Password: rt.AdminPassword,
 		Ip:       rt.Ip,

--- a/nanocloud/routes/machines/machines.go
+++ b/nanocloud/routes/machines/machines.go
@@ -41,7 +41,7 @@ type machine struct {
 	Ip            string `json:"ip"`
 	Type          string `json:"type"`
 	Status        string `json:"status"`
-	UserName      string `json:"username"`
+	Username      string `json:"username"`
 	AdminPassword string `json:"admin-password,omitempty"`
 	Platform      string `json:"platform"`
 	Progress      int    `json:"progress"`
@@ -219,7 +219,7 @@ func CreateMachine(c *echo.Context) error {
 	attr := vm.MachineAttributes{
 		Type:     nil,
 		Name:     rt.Name,
-		Username: rt.UserName,
+		Username: rt.Username,
 		Password: rt.AdminPassword,
 		Ip:       rt.Ip,
 	}

--- a/nanocloud/routes/upload/upload.go
+++ b/nanocloud/routes/upload/upload.go
@@ -39,7 +39,7 @@ func Post(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sam := rawuser.(*users.User).Sam
-	winServer := utils.Env("WIN_SERVER", "")
+	winServer := utils.Env("PLAZA", "")
 	var err error
 	request, err := http.NewRequest("POST", "http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam), r.Body)
 	if err != nil {
@@ -65,7 +65,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 	}
 	sam := rawuser.(*users.User).Sam
 
-	winServer := utils.Env("WIN_SERVER", "")
+	winServer := utils.Env("PLAZA", "")
 	var err error
 	request, err := http.NewRequest("GET", "http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam), nil)
 	if err != nil {

--- a/nanocloud/routes/upload/upload.go
+++ b/nanocloud/routes/upload/upload.go
@@ -39,7 +39,7 @@ func Post(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sam := rawuser.(*users.User).Sam
-	winServer := utils.Env("PLAZA", "")
+	winServer := utils.Env("PLAZA_ADDRESS", "")
 	var err error
 	request, err := http.NewRequest("POST", "http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam), r.Body)
 	if err != nil {
@@ -65,7 +65,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 	}
 	sam := rawuser.(*users.User).Sam
 
-	winServer := utils.Env("PLAZA", "")
+	winServer := utils.Env("PLAZA_ADDRESS", "")
 	var err error
 	request, err := http.NewRequest("GET", "http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam), nil)
 	if err != nil {

--- a/nanocloud/vms/drivers/manual/driver.go
+++ b/nanocloud/vms/drivers/manual/driver.go
@@ -23,11 +23,8 @@
 package manual
 
 import (
-	"strings"
-
 	"github.com/Nanocloud/community/nanocloud/connectors/db"
 	"github.com/Nanocloud/community/nanocloud/vms"
-	log "github.com/Sirupsen/logrus"
 )
 
 type driver struct{}
@@ -43,46 +40,5 @@ func Find(ip string) bool {
 }
 
 func (d *driver) Open(options map[string]string) (vms.VM, error) {
-	v := &vm{}
-	ad := options["ad"]
-	servers := options["servers"]
-	password := options["password"]
-	user := options["user"]
-	attr := vms.MachineAttributes{
-		Type:     nil,
-		Username: user,
-		Password: password,
-	}
-
-	if ad == servers {
-
-		if Find(ad) == false {
-			attr.Ip = ad
-			_, err := v.Create(attr)
-			if err != nil {
-				log.Error(err)
-			}
-		}
-	} else {
-
-		ips := strings.Split(servers, ";")
-		if Find(ad) == false {
-			attr.Ip = ad
-			_, err := v.Create(attr)
-			if err != nil {
-				log.Error(err)
-			}
-		}
-
-		for _, val := range ips {
-			if Find(val) == false {
-				attr.Ip = val
-				_, err := v.Create(attr)
-				if err != nil {
-					log.Error(err)
-				}
-			}
-		}
-	}
-	return v, nil
+	return &vm{}, nil
 }

--- a/nanocloud/vms/drivers/manual/driver.go
+++ b/nanocloud/vms/drivers/manual/driver.go
@@ -34,8 +34,8 @@ type driver struct{}
 
 func Find(ip string) bool {
 
-	rows, _ := db.Query(`SELECT execserver
-	FROM machines WHERE execserver = $1::varchar`, ip)
+	rows, _ := db.Query(`SELECT ip
+	FROM machines WHERE ip = $1::varchar`, ip)
 	if rows.Next() {
 		return true
 	}

--- a/nanocloud/vms/drivers/manual/driver.go
+++ b/nanocloud/vms/drivers/manual/driver.go
@@ -22,22 +22,9 @@
 
 package manual
 
-import (
-	"github.com/Nanocloud/community/nanocloud/connectors/db"
-	"github.com/Nanocloud/community/nanocloud/vms"
-)
+import "github.com/Nanocloud/community/nanocloud/vms"
 
 type driver struct{}
-
-func Find(ip string) bool {
-
-	rows, _ := db.Query(`SELECT ip
-	FROM machines WHERE ip = $1::varchar`, ip)
-	if rows.Next() {
-		return true
-	}
-	return false
-}
 
 func (d *driver) Open(options map[string]string) (vms.VM, error) {
 	return &vm{}, nil

--- a/nanocloud/vms/drivers/manual/machine.go
+++ b/nanocloud/vms/drivers/manual/machine.go
@@ -23,36 +23,37 @@
 package manual
 
 import (
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
 
-	"github.com/Nanocloud/community/nanocloud/utils"
+	"github.com/Nanocloud/community/nanocloud/connectors/db"
 	"github.com/Nanocloud/community/nanocloud/vms"
 	"github.com/labstack/gommon/log"
 )
 
 type machine struct {
-	id       string
-	server   string
-	sshport  string
-	user     string
-	password string
-	role     string
+	id        string
+	server    string
+	plazaport string
+	user      string
+	password  string
+	role      string
 }
 
 func (m *machine) Status() (vms.MachineStatus, error) {
-	resp, err := http.Get("http://" + m.server + ":" + utils.Env("PLAZA_PORT", "9090") + "/checkrds")
+	resp, err := http.Get("http://" + m.server + ":" + m.plazaport + "/checkrds")
 	if err != nil || resp.StatusCode != http.StatusOK {
 		log.Error(err)
-		return vms.StatusUnknown, err
+		return vms.StatusUnknown, nil
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Error(err)
-		return vms.StatusUnknown, err
+		return vms.StatusUnknown, nil
 	}
 
 	if strings.Contains(string(b), "Running") {
@@ -87,6 +88,17 @@ func (m *machine) Stop() error {
 }
 
 func (m *machine) Terminate() error {
+	res, err := db.Exec("DELETE FROM machines WHERE id = $1::varchar", m.id)
+	if err != nil {
+		return err
+	}
+	deleted, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if deleted == 0 {
+		return errors.New("machine entry not found")
+	}
 	return nil
 }
 
@@ -104,5 +116,5 @@ func (m *machine) Name() (string, error) {
 }
 
 func (m *machine) Credentials() (string, string, error) {
-	return "Administrator", "Nanocloud123+", nil
+	return m.user, m.password, nil
 }

--- a/nanocloud/vms/drivers/manual/machine.go
+++ b/nanocloud/vms/drivers/manual/machine.go
@@ -63,7 +63,7 @@ func (m *machine) Status() (vms.MachineStatus, error) {
 }
 
 func (m *machine) IP() (net.IP, error) {
-	return []byte(m.server), nil
+	return net.ParseIP(m.server), nil
 }
 
 func (m *machine) Type() (vms.MachineType, error) {

--- a/nanocloud/vms/drivers/manual/machine.go
+++ b/nanocloud/vms/drivers/manual/machine.go
@@ -40,7 +40,6 @@ type machine struct {
 	plazaport string
 	user      string
 	password  string
-	role      string
 }
 
 func (m *machine) Status() (vms.MachineStatus, error) {
@@ -107,12 +106,7 @@ func (m *machine) Id() string {
 }
 
 func (m *machine) Name() (string, error) {
-	if m.role == "ad" {
-		return "Windows Active Directory", nil
-	} else if m.role == "exec" {
-		return "Windows Session Host", nil
-	}
-	return "Undefined Windows Server", nil
+	return "Windows Active Directory", nil
 }
 
 func (m *machine) Credentials() (string, string, error) {

--- a/nanocloud/vms/drivers/manual/vm.go
+++ b/nanocloud/vms/drivers/manual/vm.go
@@ -48,9 +48,9 @@ func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 	}
 	rows, err := db.Query(
 		`INSERT INTO machines
-		(id, type, ad, ip, username, password)
-		VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar, $6::varchar)`,
-		machine.id, "manual", machine.server, machine.server, machine.user, machine.password)
+		(id, type, ip, username, password)
+		VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar)`,
+		machine.id, "manual", machine.server, machine.user, machine.password)
 	if err != nil {
 		return nil, err
 	}

--- a/nanocloud/vms/drivers/manual/vm.go
+++ b/nanocloud/vms/drivers/manual/vm.go
@@ -49,7 +49,7 @@ func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 	rows, err := db.Query(
 		`INSERT INTO machines
 		(id, type, ip, username, password)
-		VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar)`,
+		VALUES( $1::varchar, $2::vmtype, $3::varchar, $4::varchar, $5::varchar)`,
 		machine.id, "manual", machine.server, machine.user, machine.password)
 	if err != nil {
 		return nil, err

--- a/nanocloud/vms/drivers/manual/vm.go
+++ b/nanocloud/vms/drivers/manual/vm.go
@@ -48,7 +48,7 @@ func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 	}
 	rows, err := db.Query(
 		`INSERT INTO machines
-		(id, type, ad, execserver, username, password)
+		(id, type, ad, ip, username, password)
 		VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar, $6::varchar)`,
 		machine.id, "manual", machine.server, machine.server, machine.user, machine.password)
 	if err != nil {
@@ -61,7 +61,7 @@ func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 func (v *vm) Machines() ([]vms.Machine, error) {
 
 	rows, err := db.Query(
-		`SELECT role, type, id, execserver,
+		`SELECT type, id, ip,
 		plazaport, username, password
 		FROM machines`,
 	)
@@ -75,7 +75,6 @@ func (v *vm) Machines() ([]vms.Machine, error) {
 		machine := &machine{}
 
 		rows.Scan(
-			&machine.role,
 			&vmType,
 			&machine.id,
 			&machine.server,
@@ -97,7 +96,7 @@ func (v *vm) Machines() ([]vms.Machine, error) {
 
 func (v *vm) Machine(id string) (vms.Machine, error) {
 	rows, err := db.Query(
-		`SELECT role, id, execserver, plazaport, username, password
+		`SELECT id, ip, plazaport, username, password
 		FROM machines WHERE id = $1::varchar`, id)
 	if err != nil {
 		fmt.Println(err.Error())
@@ -106,7 +105,6 @@ func (v *vm) Machine(id string) (vms.Machine, error) {
 	machine := &machine{}
 	for rows.Next() {
 		rows.Scan(
-			&machine.role,
 			&machine.id,
 			&machine.server,
 			&machine.plazaport,

--- a/nanocloud/vms/drivers/manual/vm.go
+++ b/nanocloud/vms/drivers/manual/vm.go
@@ -23,45 +23,101 @@
 package manual
 
 import (
-	"errors"
-	"strings"
+	"fmt"
 
+	"github.com/Nanocloud/community/nanocloud/connectors/db"
 	"github.com/Nanocloud/community/nanocloud/vms"
-	log "github.com/Sirupsen/logrus"
+	"github.com/labstack/gommon/log"
+	uuid "github.com/satori/go.uuid"
 )
 
 type vm struct {
-	servers  string
-	ad       string
-	sshport  string
-	user     string
-	password string
 }
 
 func (v *vm) Types() ([]vms.MachineType, error) {
 	return []vms.MachineType{defaultType}, nil
 }
 
-func (v *vm) Create(name, password string, t vms.MachineType) (vms.Machine, error) {
-	log.Error("Not Implemented")
-	return nil, nil
+func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
+
+	machine := &machine{
+		id:       uuid.NewV4().String(),
+		server:   attr.Ip,
+		user:     attr.Username,
+		password: attr.Password,
+	}
+	rows, err := db.Query(
+		`INSERT INTO machines
+		(id, type, ad, execserver, username, password)
+		VALUES( $1::varchar, $2::varchar, $3::varchar, $4::varchar, $5::varchar, $6::varchar)`,
+		machine.id, "manual", machine.server, machine.server, machine.user, machine.password)
+	if err != nil {
+		return nil, err
+	}
+	rows.Close()
+	return machine, nil
 }
 
 func (v *vm) Machines() ([]vms.Machine, error) {
-	if v.ad == v.servers {
-		machines := make([]vms.Machine, 1)
-		machines[0] = &machine{role: "ad", id: v.ad, server: v.ad, sshport: v.sshport, user: v.user, password: v.password}
-		return machines, nil
+
+	rows, err := db.Query(
+		`SELECT role, type, id, execserver,
+		plazaport, username, password
+		FROM machines`,
+	)
+	if err != nil {
+		return nil, err
 	}
-	ips := strings.Split(v.servers, ";")
-	var machines []vms.Machine
-	machines = append(machines, &machine{role: "ad", id: v.ad, server: v.ad, sshport: v.sshport, user: v.user, password: v.password})
-	for _, val := range ips {
-		machines = append(machines, &machine{role: "exec", id: val, server: val, sshport: v.sshport, user: v.user, password: v.password})
+	defer rows.Close()
+	machines := make([]vms.Machine, 0)
+	vmType := ""
+	for rows.Next() {
+		machine := &machine{}
+
+		rows.Scan(
+			&machine.role,
+			&vmType,
+			&machine.id,
+			&machine.server,
+			&machine.plazaport,
+			&machine.user,
+			&machine.password,
+		)
+		if vmType == "manual" {
+			machines = append(machines, machine)
+		}
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
 	}
 	return machines, nil
 }
 
 func (v *vm) Machine(id string) (vms.Machine, error) {
-	return nil, errors.New("Not implemented")
+	rows, err := db.Query(
+		`SELECT role, id, execserver, plazaport, username, password
+		FROM machines WHERE id = $1::varchar`, id)
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil, err
+	}
+	machine := &machine{}
+	for rows.Next() {
+		rows.Scan(
+			&machine.role,
+			&machine.id,
+			&machine.server,
+			&machine.plazaport,
+			&machine.user,
+			&machine.password,
+		)
+	}
+	err = rows.Err()
+	if err != nil {
+		log.Error(err.Error())
+		return nil, err
+	}
+	return machine, nil
 }

--- a/nanocloud/vms/drivers/qemu/vm.go
+++ b/nanocloud/vms/drivers/qemu/vm.go
@@ -39,9 +39,9 @@ func (v *vm) Types() ([]vms.MachineType, error) {
 	return []vms.MachineType{defaultType}, nil
 }
 
-func (v *vm) Create(name, password string, t vms.MachineType) (vms.Machine, error) {
+func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 
-	m := machine{id: name, server: v.server}
+	m := machine{id: attr.Username, server: v.server}
 	ip, _ := m.IP()
 	resp, err := http.Post("http://"+string(ip)+":8080/api/vms/"+m.Id()+"/download", "", nil)
 	if err != nil || resp.StatusCode != http.StatusOK {

--- a/nanocloud/vms/drivers/qemu/vm.go
+++ b/nanocloud/vms/drivers/qemu/vm.go
@@ -41,7 +41,7 @@ func (v *vm) Types() ([]vms.MachineType, error) {
 
 func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 
-	m := machine{id: attr.Username, server: v.server}
+	m := machine{id: attr.Name, server: v.server}
 	ip, _ := m.IP()
 	resp, err := http.Post("http://"+string(ip)+":8080/api/vms/"+m.Id()+"/download", "", nil)
 	if err != nil || resp.StatusCode != http.StatusOK {

--- a/nanocloud/vms/drivers/vmwarefusion/vm.go
+++ b/nanocloud/vms/drivers/vmwarefusion/vm.go
@@ -149,7 +149,7 @@ func (v *vm) createVmxForSetup(vmId string, name string, t *machineType, hdd str
 	return dst, nil
 }
 
-func (v *vm) Create(name string, password string, rawType vms.MachineType) (vms.Machine, error) {
+func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 	h := sha1.New()
 	h.Write([]byte(uuid.NewV4().String()))
 	id := hex.EncodeToString(h.Sum(nil))[0:14]
@@ -166,11 +166,11 @@ func (v *vm) Create(name string, password string, rawType vms.MachineType) (vms.
 		return nil, errors.New("Unable to check machine id uniqueness")
 	}
 
-	if rawType == nil {
-		rawType = defaultType
+	if attr.Type == nil {
+		attr.Type = defaultType
 	}
 
-	t, ok := rawType.(*machineType)
+	t, ok := attr.Type.(*machineType)
 	if !ok {
 		return nil, errors.New("VM Type not supported")
 	}
@@ -185,12 +185,12 @@ func (v *vm) Create(name string, password string, rawType vms.MachineType) (vms.
 		return nil, err
 	}
 
-	installISO, err := v.createInstallDisk(id, password)
+	installISO, err := v.createInstallDisk(id, attr.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = v.createVmxForSetup(id, name, t, hdd, iso, installISO)
+	_, err = v.createVmxForSetup(id, attr.Username, t, hdd, iso, installISO)
 	if err != nil {
 		return nil, err
 	}

--- a/nanocloud/vms/drivers/vmwarefusion/vm.go
+++ b/nanocloud/vms/drivers/vmwarefusion/vm.go
@@ -190,7 +190,7 @@ func (v *vm) Create(attr vms.MachineAttributes) (vms.Machine, error) {
 		return nil, err
 	}
 
-	_, err = v.createVmxForSetup(id, attr.Username, t, hdd, iso, installISO)
+	_, err = v.createVmxForSetup(id, attr.Name, t, hdd, iso, installISO)
 	if err != nil {
 		return nil, err
 	}

--- a/nanocloud/vms/type.go
+++ b/nanocloud/vms/type.go
@@ -29,6 +29,7 @@ type MachineType interface {
 
 type MachineAttributes struct {
 	Type     MachineType
+	Name     string
 	Username string
 	Password string
 	Ip       string

--- a/nanocloud/vms/type.go
+++ b/nanocloud/vms/type.go
@@ -26,3 +26,10 @@ type MachineType interface {
 	Id() string
 	Label() string
 }
+
+type MachineAttributes struct {
+	Type     MachineType
+	Username string
+	Password string
+	Ip       string
+}

--- a/nanocloud/vms/vm.go
+++ b/nanocloud/vms/vm.go
@@ -25,6 +25,6 @@ package vms
 type VM interface {
 	Machines() ([]Machine, error)
 	Machine(id string) (Machine, error)
-	Create(name, password string, t MachineType) (Machine, error)
+	Create(attr MachineAttributes) (Machine, error)
 	Types() ([]MachineType, error)
 }


### PR DESCRIPTION
For now, env variables are still used to initialise the database, because it is still not possible to add a machine from the front
