### PR TITLE
Fix file explorer not working as user if session never was opened

### DIFF
--- a/nanocloud/errors/errors.go
+++ b/nanocloud/errors/errors.go
@@ -67,4 +67,10 @@ var (
 		"Windows is not available.",
 	}
 
+	NeedFirstConnection = &apiError{
+		0x000008,
+		http.StatusServiceUnavailable,
+		"The features requires a first connection to Windows to be available",
+	}
+
 )

--- a/nanocloud/routes/files/files.go
+++ b/nanocloud/routes/files/files.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"io/ioutil"
 
 	"fmt"
 	apiErrors "github.com/Nanocloud/community/nanocloud/errors"
@@ -265,7 +266,12 @@ func Get(c *echo.Context) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("Unable to retrieve the file")
+		contents, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.New("Unable to retrieve the file")
+		}
+
+		return apiErrors.NeedFirstConnection.Detail(string(contents))
 	}
 
 	var contentType string

--- a/webapp/app/components/vdi-download/component.js
+++ b/webapp/app/components/vdi-download/component.js
@@ -13,7 +13,12 @@ export default VdiWindowComponent.extend({
       .then(function(response) {
         this.set('items', response);
       }.bind(this))
-      .catch(() => {
+      .catch((err) => {
+        // If windows has to be ran once
+        if (err.errors.length === 1 && err.errors[0].code === "000008") {
+          return ;
+        }
+
         this.toast.error("Couldn't retrieve files");
       });
 
@@ -25,4 +30,3 @@ export default VdiWindowComponent.extend({
     },
   }
 });
-

--- a/webapp/app/protected/files/index/route.js
+++ b/webapp/app/protected/files/index/route.js
@@ -11,7 +11,11 @@ export default Ember.Route.extend({
         if (err.errors.length === 1 && err.errors[0].code === "000007") {
           this.toast.warning("Cannot list files because Windows is not running");
           this.transitionTo('protected.files.nowindows');
-        } else {
+        } else if (err.errors.length === 1 && err.errors[0].code === "000008") {
+          this.toast.warning("You need to login once to an application to activate this feature");
+          this.transitionTo('protected.files.notactivated');
+        }
+          else {
           return this.send("error", err);
         }
       });

--- a/webapp/app/protected/files/notactivated/route.js
+++ b/webapp/app/protected/files/notactivated/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/webapp/app/protected/files/notactivated/template.hbs
+++ b/webapp/app/protected/files/notactivated/template.hbs
@@ -1,0 +1,16 @@
+<div class="section p-a-2">
+  <h4>Files</h4>
+  <div class='content-wrapper'>
+    <div class="alert alert-info" role="alert">
+      <strong>It seems like you never connect to any applications yet</strong>
+      <br />
+      This feature requires a first successful connection to an application to be available.<br />
+      Click "Go to applications" to be redirected to the page were you will be able launch your apps
+    </div>
+    {{#link-to "protected.apps"}}
+      <button class='btn btn-primary btn-block'>
+        Go to applications
+      </button>
+    {{/link-to}}
+  </div>
+</div>

--- a/webapp/app/router.js
+++ b/webapp/app/router.js
@@ -20,6 +20,7 @@ Router.map(function() {
     });
     this.route('files', function() {
       this.route('nowindows');
+      this.route('notactivated');
     });
     this.route('histories', function() {});
   });

--- a/webapp/tests/unit/protected/files/notactivated/route-test.js
+++ b/webapp/tests/unit/protected/files/notactivated/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:protected/files/notactivated', 'Unit | Route | protected/files/notactivated', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
API to return NeedFirstConnection error type if Windows session needs to be opened once before accessing resource.
Invite user to launch session for the first time in order to access file list.
Do not toast an error if file could not be retrieved because Nanocloud folder never was ever created on user's desktop.
