### PR TITLE
fix cancel button not working on file upload

### DIFF
--- a/webapp/app/components/drag-n-drop/component.js
+++ b/webapp/app/components/drag-n-drop/component.js
@@ -44,7 +44,7 @@ export default Ember.Component.extend({
     });
 
     this.flow.assignDrop(this.element);
-    this.flow.assignBrowse(this.element);
+    this.flow.assignBrowse($(this.element).find('.drag-n-drop-container'));
 
     this.flow.on('filesSubmitted', (array) => {
       this.set('queue', array);


### PR DESCRIPTION
prevent cancel button from triggering the file explorer by giving 'drag-n-drop-container' element instead of the whole component
