### PR TITLE
Published applications are stored in database right after publication rather than waiting for the check loop

### DIFF
--- a/nanocloud/main.go
+++ b/nanocloud/main.go
@@ -30,7 +30,6 @@ import (
 	apiErrors "github.com/Nanocloud/community/nanocloud/errors"
 	m "github.com/Nanocloud/community/nanocloud/middlewares"
 	"github.com/Nanocloud/community/nanocloud/migration"
-	appsModel "github.com/Nanocloud/community/nanocloud/models/apps"
 	_ "github.com/Nanocloud/community/nanocloud/models/oauth"
 	"github.com/Nanocloud/community/nanocloud/routes/apps"
 	"github.com/Nanocloud/community/nanocloud/routes/files"
@@ -92,7 +91,6 @@ func main() {
 		return
 	}
 	p := echo.New()
-	p.Post("/app", apps.AddApplication)
 	go p.Run(":8181")
 
 	err = initVms()
@@ -116,8 +114,6 @@ func main() {
 	e.Post("/api/applications", m.OAuth2(m.Admin(apps.PublishApplication)))
 	e.Get("/api/applications/connections", m.OAuth2(apps.GetConnections))
 	e.Patch("/api/applications/:app_id", m.OAuth2(m.Admin(apps.ChangeAppName)))
-
-	go appsModel.CheckPublishedApps()
 
 	/**
 	 * SESSIONS

--- a/nanocloud/migration/apps/apps.go
+++ b/nanocloud/migration/apps/apps.go
@@ -44,7 +44,7 @@ func Migrate() error {
 	}
 	rows, err = db.Query(
 		`CREATE TABLE apps (
-			id	SERIAL PRIMARY KEY,
+			id	varchar(36) PRIMARY KEY,
 			collection_name		varchar(36),
 			alias		varchar(36) UNIQUE,
 			display_name		varchar(36),

--- a/nanocloud/plaza/plaza.go
+++ b/nanocloud/plaza/plaza.go
@@ -1,0 +1,158 @@
+/*
+ * Nanocloud Community, a comprehensive platform to turn any application
+ * into a cloud solution.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud community.
+ *
+ * Nanocloud community is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud community is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package plaza
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type cmd_t struct {
+	Username string   `json:"username"`
+	Password string   `json:"password"`
+	Domain   string   `json:"domain"`
+	Command  []string `json:"command"`
+	Stdin    string   `json:"stdin"`
+}
+
+type result_t struct {
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+	Code   uint64 `json:"code"`
+	// Time   uint64 `json:"time"`
+}
+
+func Exec(address string, port int, cmd *cmd_t) (*result_t, error) {
+	var err error
+
+	client := &http.Client{}
+
+	instr, err := json.Marshal(&cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	buff := bytes.NewBuffer(instr)
+
+	var resp *http.Response
+
+	for i := 0; i < 10; i++ {
+		resp, err = client.Post(
+			fmt.Sprintf("http://%s:%d/exec", address, port),
+			"application/json",
+			buff,
+		)
+		if err == nil {
+			break
+		} else {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(string(body))
+	}
+
+	r := result_t{}
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+func PowershellExec(
+	address string, port int,
+	username string, domain string, password string,
+	command ...string,
+) (*result_t, error) {
+	cmd := cmd_t{
+		Username: username,
+		Password: password,
+		Domain:   domain,
+		Command: []string{
+			"C:\\Windows\\System32\\WindowsPowershell\\v1.0\\powershell.exe",
+			"-Command",
+			"-",
+		},
+		Stdin: strings.Join(command, " "),
+	}
+
+	res, err := Exec(address, port, &cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Code != 0 {
+		return nil, errors.New(res.Stdout)
+	}
+	return res, nil
+}
+
+func PublishApp(
+	address string, port int,
+	username string, domain string, password string,
+	collectionName string, displayName string, filePath string,
+) ([]byte, error) {
+	res, err := PowershellExec(
+		address, port,
+		username, domain, password,
+		"Try {",
+		"Import-module RemoteDesktop;",
+		fmt.Sprintf(
+			"New-RDRemoteApp -CollectionName '%s' -DisplayName '%s' -FilePath '%s' -ErrorAction Stop | ConvertTo-Json",
+			collectionName, displayName, filePath,
+		),
+		"}",
+		"Catch {",
+		"$ErrorMessage = $_.Exception.Message;",
+		"Write-Output -InputObject $ErrorMessage;",
+		"exit 1;",
+		"}",
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	out := res.Stdout
+
+	return []byte(out), nil
+}

--- a/nanocloud/routes/apps/apps.go
+++ b/nanocloud/routes/apps/apps.go
@@ -121,6 +121,8 @@ func ListApplications(c *echo.Context) error {
 
 // Make an application unusable
 func UnpublishApplication(c *echo.Context) error {
+	user := c.Get("user").(*users.User)
+
 	appId := c.Param("app_id")
 	if len(appId) < 1 {
 		return c.JSON(http.StatusBadRequest, hash{
@@ -132,7 +134,7 @@ func UnpublishApplication(c *echo.Context) error {
 		})
 	}
 
-	err := apps.UnpublishApp(appId)
+	err := apps.UnpublishApp(user, appId)
 	if err == apps.UnpublishFailed {
 		return c.JSON(http.StatusInternalServerError, hash{
 			"error": [1]hash{

--- a/nanocloud/routes/apps/apps.go
+++ b/nanocloud/routes/apps/apps.go
@@ -148,51 +148,21 @@ func UnpublishApplication(c *echo.Context) error {
 	})
 }
 
-func AddApplication(c *echo.Context) error {
-	var p apps.Application
-
-	err := utils.ParseJSONBody(c, &p)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, hash{
-			"error": [1]hash{
-				hash{
-					"detail": "App infos are invalid",
-				},
-			},
-		})
-	}
-	err = apps.AddApp(p)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, hash{
-			"error": [1]hash{
-				hash{
-					"detail": err,
-				},
-			},
-		})
-	}
-	return c.JSON(http.StatusOK, hash{
-		"data": hash{
-			"success": true,
-		},
-	})
-}
-
 func PublishApplication(c *echo.Context) error {
-	err := apps.PublishApp(c.Request().Body)
-	if err == apps.PublishFailed {
-		return c.JSON(http.StatusInternalServerError, hash{
-			"error": [1]hash{
-				hash{
-					"detail": err,
-				},
-			},
-		})
+	app := &apps.Application{}
+	err := utils.ParseJSONBody(c, app)
+	if err != nil {
+		return err
 	}
 
-	return c.JSON(http.StatusOK, hash{
-		"meta": hash{},
-	})
+	user := c.Get("user").(*users.User)
+
+	err = apps.PublishApp(user, app)
+	if err != nil {
+		return err
+	}
+
+	return utils.JSON(c, http.StatusOK, app)
 }
 
 func ChangeAppName(c *echo.Context) error {


### PR DESCRIPTION
Puiblish and Unpublish now use the plaza `/exec` endpoints.
The publish status is retrieved right after the publication with the icon info. We can insert the app in Postgres after the publish instead of using the check loop the keep the db in sync with AD.
The application ID is now a UUID instead of an int.
