### PR TITLE
Bugfix: keyboard not being re-attach properly when toggling copy paste 

### DIFF
--- a/webapp/app/components/topbar-item/template.hbs
+++ b/webapp/app/components/topbar-item/template.hbs
@@ -1,9 +1,9 @@
-<div class='topbar-item {{ if clickable "clickable" }} {{ if hover-enabled "hover-enabled" }} {{ if hover-darker "hover-darker" }} {{ if adjustIcon "adjustIcon" }}'>
+<div {{ action "clickAction"}} class='topbar-item {{ if clickable "clickable" }} {{ if hover-enabled "hover-enabled" }} {{ if hover-darker "hover-darker" }} {{ if adjustIcon "adjustIcon" }}'>
   {{#if materialIcon }}
-    <i class="material-icons" {{ action "clickAction"}}>{{ materialIcon }}</i>
+    <i class="material-icons">{{ materialIcon }}</i>
   {{/if}}
 
   {{#if textContent}}
-    <span class="link clickable" {{ action "clickAction"}}>{{ textContent }}</span>
+    <span class="link clickable">{{ textContent }}</span>
   {{/if}}
 </div>

--- a/webapp/app/components/vdi-clipboard/component.js
+++ b/webapp/app/components/vdi-clipboard/component.js
@@ -4,7 +4,6 @@ import VdiWindowComponent from 'nanocloud/components/vdi-window/component';
 export default VdiWindowComponent.extend({
 
   remoteSession: Ember.inject.service('remote-session'),
-  hasFocus: false,
   localClipboardContent: null,
 
   updateCloudClipboardOnTyping: function() {
@@ -18,15 +17,6 @@ export default VdiWindowComponent.extend({
     Ember.defineProperty(this, 'cloudClipboardContent', Ember.computed.alias(`remoteSession.openedGuacSession.${connectionName}.cloudClipboard`));
   },
 
-  mouseEnter() {
-      this.set('hasFocus', false);
-      this.get('remoteSession').pauseInputs(this.get('connectionName'));
-  },
-
-  mouseLeave() {
-      this.set('hasFocus', true);
-      this.get('remoteSession').restoreInputs(this.get('connectionName'));
-  },
 
   actions: {
 

--- a/webapp/app/components/vdi-clipboard/template.hbs
+++ b/webapp/app/components/vdi-clipboard/template.hbs
@@ -3,6 +3,7 @@
 {{/if}}
 {{#vdi-window
   title="Clipboard"
+  connectionName=connectionName
   windowClass="vdi-clipboard"
   stateVisible=stateVisible}}
 

--- a/webapp/app/components/vdi-window/component.js
+++ b/webapp/app/components/vdi-window/component.js
@@ -4,24 +4,23 @@ export default Ember.Component.extend({
 
 
   remoteSession: Ember.inject.service('remote-session'),
-  hasFocus: false,
 
-  mouseEnter() {
-    console.log("ENTER");
-    this.set('hasFocus', false);
-    this.get('remoteSession').pauseInputs(this.get('connectionName'));
-  },
+  inputFocusChanged: function() {
+    if (this.$().find('textarea').length != 0) {
+      this.$().find('textarea')
+        .focusin(function() {
+          this.get('remoteSession').pauseInputs(this.get('connectionName'));
+        }.bind(this))
+        .focusout(function() {
+          this.get('remoteSession').restoreInputs(this.get('connectionName'));
+        }.bind(this));
+    }
+  }.on('didInsertElement'),
 
-  mouseLeave() {
-    console.log("LEAVE");
-    this.set('hasFocus', true);
-    this.get('remoteSession').restoreInputs(this.get('connectionName'));
-  },
 
   actions: {
     toggleVdiWindow() {
       if (this.get('toggleWindow')) {
-
         this.toggleWindow();
       }
       else {

--- a/webapp/app/components/vdi-window/component.js
+++ b/webapp/app/components/vdi-window/component.js
@@ -2,9 +2,26 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
+
+  remoteSession: Ember.inject.service('remote-session'),
+  hasFocus: false,
+
+  mouseEnter() {
+    console.log("ENTER");
+    this.set('hasFocus', false);
+    this.get('remoteSession').pauseInputs(this.get('connectionName'));
+  },
+
+  mouseLeave() {
+    console.log("LEAVE");
+    this.set('hasFocus', true);
+    this.get('remoteSession').restoreInputs(this.get('connectionName'));
+  },
+
   actions: {
     toggleVdiWindow() {
       if (this.get('toggleWindow')) {
+
         this.toggleWindow();
       }
       else {


### PR DESCRIPTION
- add focusin/focusout event on window's inputs to handle keyboard pause/attach.
- when clicking on topbar item, set the click event on the whole element instead of the icon to avoid missclick
- remove hasFocus value in vdi-window component
