### PR TITLE
Bugfix shouldn't open new tab when downloading a file

### DIFF
--- a/webapp/app/download/service.js
+++ b/webapp/app/download/service.js
@@ -12,7 +12,7 @@ export default Ember.Service.extend({
     })
     .then((response) => {
       let url = "/api/files?filename=" + encodeURIComponent("./" + filename) + "&token=" + encodeURIComponent(response.token); 
-      window.open(url);
+      window.location.assign(url);
     });
   }
 });


### PR DESCRIPTION
using window.location.assign to download file
