### PR TITLE
Parametrize VMs names on Openstack automatic deployment

### DIFF
--- a/tests/deployment/openstack/README.md
+++ b/tests/deployment/openstack/README.md
@@ -36,6 +36,8 @@ Optionnally these parameters can also be changed:
 - *DEPLOYMENT_OS_SSH_PORT* (default 22) SSH port on Linux Server
 - *DEPLOYMENT_INSTALLATION_SCRIPT* (default ./installCommunity.sh) Script installing community on provisionned VM
 - *DEPLOYMENT_PUBLIC_IP* Set a particular public IP to your deployment
+- *DEPLOYMENT_LINUX_VM_NAME* Give a name to Linux machine on Openstack
+- *DEPLOYMENT_WINDOWS_VM_NAME* Give a name to Windows machine on Openstack
 
 
 Then build the container:

--- a/tests/deployment/openstack/deploy.js
+++ b/tests/deployment/openstack/deploy.js
@@ -47,6 +47,8 @@ var WINDOWS_SECURITY_GROUPS = process.env.DEPLOYMENT_WINDOWS_SECURITY_GROUPS.spl
   "SSH",
   "RDP"
 ];
+var LINUX_VM_NAME = process.env.DEPLOYMENT_LINUX_VM_NAME || 'Bamboo Linux';
+var WINDOWS_VM_NAME = process.env.DEPLOYMENT_WINDOWS_VM_NAME || 'Bamboo Windows';
 
 var nanoOS = require('./libnanoOpenstack');
 var async = require('async');
@@ -69,7 +71,7 @@ var provisionLinux = function(callback) {
     function(next) { // Boot Linux server
 
       project.createServer({
-        "name": "Bamboo Linux",
+        "name": LINUX_VM_NAME,
         "imageRef": URL + ":9292/v2/images/" + LINUX_IMAGE_ID,
         "flavorRef": URL + ":8774/v2/flavors/2",
         "key_name": KEY_NAME
@@ -186,7 +188,7 @@ var provisionWindows = function(callback) {
     function(next) { // Upload qcow2
       if (WINDOWS_IMAGE_ID === null) {
         project.uploadImage(WINDOWS_IMAGE_PATH, {
-          name: "bamboo",
+          name: WINDOWS_VM_NAME + " image",
           visibility: 'private',
           disk_format: 'qcow2',
           container_format: 'bare'
@@ -205,7 +207,7 @@ var provisionWindows = function(callback) {
       }
 
       project.createServer({
-        "name": "Bamboo Windows",
+        "name": WINDOWS_VM_NAME,
         "imageRef": URL + ":9292/v2/images/" + imageId,
         "flavorRef": URL + ":8774/v2/flavors/3"
       }, function(error, _server) {


### PR DESCRIPTION
Add 2 environment variable to set Linux and Windows VM names on Openstack
Reuse Windows VM name to give a name to windows image
