### PR TITLE
Use firewall rule's name instead of display group for RDP

### DIFF
--- a/plaza/routes/provisioning/provisioning.go
+++ b/plaza/routes/provisioning/provisioning.go
@@ -68,7 +68,7 @@ var commands = [][]string{
 	},
 	{
 		"set-ItemProperty -Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server'-name 'fDenyTSConnections' -Value 0",
-		"Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'",
+		"Enable-NetFirewallRule -Name 'RemoteDesktop-UserMode-In-TCP'",
 		"set-ItemProperty -Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' -name 'UserAuthentication' -Value 1",
 	},
 	{


### PR DESCRIPTION
In order to allow provisioning on non English systems.
