### PR TITLE
Hide machine commands when no drivers are detected

### DIFF
--- a/webapp/app/machine/model.js
+++ b/webapp/app/machine/model.js
@@ -34,4 +34,12 @@ export default DS.Model.extend({
           return "No drivers detected";
     }
   }),
+
+  driverDetected: Ember.computed('platform', function() {
+    let platform = this.get('getPlatform');
+    if (platform === "No drivers detected") {
+      return false;
+    }
+    return true;
+  }),
 });

--- a/webapp/app/protected/machines/machine/template.hbs
+++ b/webapp/app/protected/machines/machine/template.hbs
@@ -8,6 +8,7 @@
   <div class='content-wrapper'>
     <table class="table">
       <tbody>
+        {{#if model.driverDetected}}
         <tr>
           <th scope="row">Command</th>
           <td>
@@ -24,6 +25,7 @@
             </div>
           </td>
         </tr>
+        {{/if}}
         <tr>
           <th scope="row">Machine state</th>
           <td>{{model.status}}</td>


### PR DESCRIPTION
create a property in model that observes platform property and return a bool that indicates whether a driver has been detected or not.
