### PR TITLE
Use docker to build both windows and linux version of plaza

### DIFF
--- a/plaza/Dockerfile
+++ b/plaza/Dockerfile
@@ -5,5 +5,5 @@ MAINTAINER \
 COPY ./ /go/src/github.com/Nanocloud/community/plaza
 WORKDIR /go/src/github.com/Nanocloud/community/plaza
 
-RUN ./install.sh && ./build.sh
-CMD ["sleep", "30"]
+RUN ./install.sh
+CMD ["./build.sh"]

--- a/plaza/README.md
+++ b/plaza/README.md
@@ -29,3 +29,11 @@ export GOOS=linux
 export GOARCH=amd64
 ./build.sh
 ```
+
+You can also use docker to build *linux* version of plaza
+
+```
+export GOOS=linux
+export GOARCH=amd64
+./build.sh docker
+```

--- a/plaza/build.sh
+++ b/plaza/build.sh
@@ -26,8 +26,15 @@ GOARCH=${GOARCH:-amd64}
 
 if [ "${COMMAND}" = "docker" ]; then
     docker build -t nanocloud/plaza .
-    docker run -d --name plaza nanocloud/plaza
-    docker cp plaza:/go/src/github.com/Nanocloud/community/plaza/plaza.exe .
+    docker run \
+        -e "GOOS=${GOOS}" \
+        -e "GOARCH=${GOARCH}" \
+        -i --name plaza nanocloud/plaza ./build.sh
+    if [ "${GOOS}" = "windows" ]; then
+      docker cp plaza:/go/src/github.com/Nanocloud/community/plaza/plaza.exe .
+    else
+      docker cp plaza:/go/src/github.com/Nanocloud/community/plaza/plaza .
+    fi
     docker kill plaza
     docker rm plaza
     docker rmi nanocloud/plaza


### PR DESCRIPTION
Adapt _build.sh_ script to allow user to build windows or linux version with docker:

```
# Windows build
./build.sh docker
```

```
# Linux build
GOOS=linux GOARCH=amd64 ./build.sh docker
```
