### PR TITLE
Make qemu driver to return net.ParseIP instead of a byte array

### DIFF
--- a/nanocloud/vms/drivers/qemu/machine.go
+++ b/nanocloud/vms/drivers/qemu/machine.go
@@ -90,7 +90,7 @@ func (m *machine) Status() (vms.MachineStatus, error) {
 }
 
 func (m *machine) IP() (net.IP, error) {
-	return []byte(m.server), nil
+	return net.ParseIP(m.server), nil
 }
 
 func (m *machine) Type() (vms.MachineType, error) {


### PR DESCRIPTION
Like other drivers, qemu should return a ParseIP instead of a byte array to prevent casting in later use.
