### PR TITLE
Fixing route session

### DIFF
--- a/nanocloud/models/sessions/session.go
+++ b/nanocloud/models/sessions/session.go
@@ -5,6 +5,7 @@ type Session struct {
 	SessionName string `json:"session-name"`
 	Username    string `json:"username"`
 	State       string `json:"state"`
+	UserId      string `json:"user-id"`
 }
 
 func (h *Session) GetID() string {

--- a/plaza/routes/sessions/sessions.go
+++ b/plaza/routes/sessions/sessions.go
@@ -39,7 +39,7 @@ func formatResponse(tab []string, id string) [][]string {
 	for _, val := range tab {
 		newtab := strings.Fields(val)
 		if len(newtab) == 4 {
-			if newtab[1] == id {
+			if id == "Administrator" || newtab[1] == id {
 				format = append(format, newtab)
 			}
 		}

--- a/webapp/app/session/model.js
+++ b/webapp/app/session/model.js
@@ -7,4 +7,5 @@ export default Model.extend({
     sessionName: DS.attr('string'),
     username: DS.attr('string'),
     state: DS.attr('string'),
+    userId: DS.attr('string'),
 });


### PR DESCRIPTION
Since 'sam' columm has been removed from user table, 
fetching session now returns user-id.
