### PR TITLE
Send users UUID to linux based Plaza API endpoints

### DIFF
--- a/nanocloud/routes/files/files.go
+++ b/nanocloud/routes/files/files.go
@@ -265,7 +265,7 @@ func Get(c *echo.Context) error {
 			path = filepath.Join(
 				fmt.Sprintf(
 					utils.Env("PLAZA_USER_DIR", "/opt/Users/%s"),
-					user.Id,
+					"u"+user.Id[:20],
 				),
 				filename,
 			)

--- a/nanocloud/routes/upload/upload.go
+++ b/nanocloud/routes/upload/upload.go
@@ -50,7 +50,11 @@ func Post(w http.ResponseWriter, r *http.Request) {
 	sam := winUser.Sam
 	winServer := utils.Env("PLAZA_ADDRESS", "iaas-module")
 
-	request, err := http.NewRequest("POST", "http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam), r.Body)
+	request, err := http.NewRequest(
+		"POST",
+		"http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam)+"&userId="+url.QueryEscape(user.Id),
+		r.Body,
+	)
 	if err != nil {
 		log.Println("Unable de create request ", err)
 	}
@@ -84,7 +88,11 @@ func Get(w http.ResponseWriter, r *http.Request) {
 	sam := winUser.Sam
 	winServer := utils.Env("PLAZA_ADDRESS", "iaas-module")
 
-	request, err := http.NewRequest("GET", "http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam), nil)
+	request, err := http.NewRequest(
+		"GET",
+		"http://"+winServer+":"+utils.Env("PLAZA_PORT", "9090")+"/upload?sam="+url.QueryEscape(sam)+"&userId="+url.QueryEscape(user.Id),
+		nil,
+	)
 	if err != nil {
 		log.Println("Unable de create request ", err)
 	}

--- a/plaza/routes/files/files.go
+++ b/plaza/routes/files/files.go
@@ -50,21 +50,14 @@ type file_t struct {
 
 var kUploadDir string
 
-func getUploadDir(sam string) string {
-	plazaDir := os.Getenv("PLAZA_USER_DIR")
-	if plazaDir == "" {
-		plazaDir = "C:\\Users\\%s\\Desktop\\Nanocloud"
-	}
-	return fmt.Sprintf(plazaDir, sam)
-}
-
 // Get checks a chunk.
 // If it doesn't exist then flowjs tries to upload it via Post.
 func GetUpload(w http.ResponseWriter, r *http.Request) {
 	sam := r.URL.Query()["sam"][0]
+	userId := r.URL.Query()["userId"][0]
 
 	log.Error(sam)
-	kUploadDir = getUploadDir(sam)
+	kUploadDir = getUploadDir(sam, userId)
 	if _, err := os.Stat(kUploadDir); err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(kUploadDir, 0711)
@@ -91,9 +84,10 @@ func GetUpload(w http.ResponseWriter, r *http.Request) {
 // Post tries to get and save a chunk.
 func Post(w http.ResponseWriter, r *http.Request) {
 	sam := r.URL.Query()["sam"][0]
+	userId := r.URL.Query()["userId"][0]
 
 	log.Error(sam)
-	kUploadDir = getUploadDir(sam)
+	kUploadDir = getUploadDir(sam, userId)
 	if _, err := os.Stat(kUploadDir); err != nil {
 		if os.IsNotExist(err) {
 			err := os.MkdirAll(kUploadDir, 0711)

--- a/plaza/routes/files/files_linux.go
+++ b/plaza/routes/files/files_linux.go
@@ -45,3 +45,11 @@ func loadFileId(filepath string) (string, error) {
 func isFileHidden(file os.FileInfo) bool {
 	return file.Name()[0] == '.'
 }
+
+func getUploadDir(sam string, userId string) string {
+	plazaDir := os.Getenv("PLAZA_USER_DIR")
+	if plazaDir == "" {
+		plazaDir = "/opt/Users/%s"
+	}
+	return fmt.Sprintf(plazaDir, userId)
+}

--- a/plaza/routes/files/files_linux.go
+++ b/plaza/routes/files/files_linux.go
@@ -51,5 +51,5 @@ func getUploadDir(sam string, userId string) string {
 	if plazaDir == "" {
 		plazaDir = "/opt/Users/%s"
 	}
-	return fmt.Sprintf(plazaDir, userId)
+	return fmt.Sprintf(plazaDir, "u"+userId[:20])
 }

--- a/plaza/routes/files/files_windows.go
+++ b/plaza/routes/files/files_windows.go
@@ -56,3 +56,11 @@ func isFileHidden(file os.FileInfo) bool {
 	}
 	return false
 }
+
+func getUploadDir(sam string, userId string) string {
+	plazaDir := os.Getenv("PLAZA_USER_DIR")
+	if plazaDir == "" {
+		plazaDir = "C:\\Users\\%s\\Desktop\\Nanocloud"
+	}
+	return fmt.Sprintf(plazaDir, sam)
+}


### PR DESCRIPTION
A Unix account must:
- respect this regexp : [a-z_][a-z0-9_-]*[$]
- Less than 32 char long

So, to transform UUID into Unix account name, I add "u" before 20 first char of Users UUID.
