### PR TITLE
Breadcrumb in machine detail page display an empty string

### DIFF
--- a/webapp/app/protected/machines/machine/controller.js
+++ b/webapp/app/protected/machines/machine/controller.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
-  machineName: Ember.computed('model.name', 'model.name', function() {
+  machineName: Ember.computed('model.name', function() {
     return this.get('model.name') ? this.get('model.name') : "Machine";
   }),
 

--- a/webapp/app/protected/machines/machine/controller.js
+++ b/webapp/app/protected/machines/machine/controller.js
@@ -1,6 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+
+  machineName: Ember.computed('model.name', 'model.name', function() {
+    return this.get('model.name') ? this.get('model.name') : "Machine";
+  }),
+
   startMachine() {
     let machine = this.get('model');
 

--- a/webapp/app/protected/machines/machine/template.hbs
+++ b/webapp/app/protected/machines/machine/template.hbs
@@ -3,7 +3,7 @@
     {{#link-to 'protected.machines' }}
       Machines
     {{/link-to}}
-   - {{model.name}}
+   > {{machineName}}
   </h4>
   <div class='content-wrapper'>
     <table class="table">


### PR DESCRIPTION
Machine name breadcrumb should display a default name when a virtual machine has no name
