### PR TITLE
Bugfix: In machine page, Machines are not display properly in huge resolution

### DIFF
--- a/webapp/app/styles/machines.scss
+++ b/webapp/app/styles/machines.scss
@@ -1,7 +1,7 @@
 .machines {
   .machines-wrapper {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     flex-wrap: wrap;
     
     .item {


### PR DESCRIPTION
Change justify-content property using flex-start instead of space-between 
