### PR TITLE
Optimize frontend build time by caching dependencies in upper layers

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -5,13 +5,17 @@ RUN npm install -g bower
 
 RUN mkdir -p /opt/front
 WORKDIR /opt/front
+
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN cp -a /tmp/node_modules /opt/front
+
+COPY bower.json /tmp/bower.json
+RUN cd /tmp && bower install --allow-root
+RUN cp -a /tmp/bower_components /opt/front
+
 COPY ./ /opt/front/
 
-ADD package.json /tmp/package.json
-RUN cd /tmp && npm install
-
-RUN cp -r /tmp/node_modules /opt/front/
-RUN bower install --allow-root
 RUN ./node_modules/ember-cli/bin/ember build --environment=production
 
 EXPOSE 8080


### PR DESCRIPTION
From now on, npm install and bower install are performed prior to source code being copied.
This allows cache reusage in case dependency lists were not updated.
