### PR TITLE
Fix backend was not waiting for postgres to launch

### DIFF
--- a/docker-compose-canary.yml
+++ b/docker-compose-canary.yml
@@ -21,6 +21,8 @@ services:
   volumes_from:
    - nanocloud-frontend
   image: nanocloud/nanocloud-backend
+  depends_on:
+    - postgres
 
  nanocloud-frontend:
   extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
   volumes_from:
    - nanocloud-frontend
   image: nanocloud/nanocloud-backend:0.7.0
+  depends_on:
+    - postgres
 
  nanocloud-frontend:
   extends:

--- a/modules/docker-compose-build.yml
+++ b/modules/docker-compose-build.yml
@@ -23,6 +23,8 @@ services:
   volumes_from:
    - nanocloud-frontend
   image: nanocloud/nanocloud-backend
+  depends_on:
+    - postgres
 
  nanocloud-frontend:
   build: ../webapp

--- a/modules/docker-compose-dev.yml
+++ b/modules/docker-compose-dev.yml
@@ -34,6 +34,8 @@ services:
   volumes:
    - ../nanocloud:/go/src/github.com/Nanocloud/community/nanocloud/
   image: nanocloud/nanocloud-backend:dev
+  depends_on:
+    - postgres
 
  nanocloud-frontend:
   extends:

--- a/modules/docker-compose-test.yml
+++ b/modules/docker-compose-test.yml
@@ -21,6 +21,8 @@ services:
   volumes_from:
    - nanocloud-frontend
   image: nanocloud/nanocloud-backend
+  depends_on:
+    - postgres
 
  nanocloud-frontend:
   extends:


### PR DESCRIPTION
It used to be possible the backend launches before postgres was able to accept connection.
backend's container now explicitly depends on postgres.
