### PR TITLE
Optimize build time by caching dependencies in upper layers

### DIFF
--- a/modules/iaas/Dockerfile
+++ b/modules/iaas/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER \
   Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
 RUN mkdir -p /go/build/iaas
-RUN mkdir -p /go/src/github.com/Nanocloud/community/nanocloud
-WORKDIR /go/src/github.com/Nanocloud/community/nanocloud
+RUN mkdir -p /go/src/github.com/Nanocloud/community/modules/iaas
+WORKDIR /go/src/github.com/Nanocloud/community/modules/iaas
 
 RUN apt-get update && \
     apt-get -y install git qemu-system-x86 genisoimage

--- a/modules/iaas/Dockerfile
+++ b/modules/iaas/Dockerfile
@@ -1,19 +1,22 @@
 FROM golang:1.6
 MAINTAINER \
   William Riancho <william.riancho@nanocloud.com> \
-  Olivier Berthonneau <olivier.berthonneau@nanocloud.com> 
+  Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
+RUN mkdir -p /go/build/iaas
+RUN mkdir -p /go/src/github.com/Nanocloud/community/nanocloud
+WORKDIR /go/src/github.com/Nanocloud/community/nanocloud
 
 RUN apt-get update && \
     apt-get -y install git qemu-system-x86 genisoimage
 
-RUN mkdir -p /go/build/iaas
+COPY install.sh /tmp/install.sh
+RUN cd /tmp && ./install.sh
+RUN cp -a /tmp/vendor /go/src/github.com/Nanocloud/community/modules/iaas
 
 COPY ./ /go/src/github.com/Nanocloud/community/modules/iaas
 
-WORKDIR /go/src/github.com/Nanocloud/community/modules/iaas
-
-RUN ./install.sh && go build
+RUN go build
 
 EXPOSE 9090
 CMD ["./iaas"]

--- a/modules/iaas/Dockerfile
+++ b/modules/iaas/Dockerfile
@@ -15,6 +15,5 @@ WORKDIR /go/src/github.com/Nanocloud/community/modules/iaas
 
 RUN ./install.sh && go build
 
-EXPOSE 8080
 EXPOSE 9090
 CMD ["./iaas"]

--- a/modules/iaas/install.sh
+++ b/modules/iaas/install.sh
@@ -31,16 +31,23 @@ clone() {
     echo -n "$pkg @ $rev: "
 
     if [ -d "$target" ]; then
-        echo -n 'rm old, '
-        rm -rf "$target"
+
+	if [ "$rev" != "master" ]; then
+	    CURRENT_HASH=$(cd "$target" ; git rev-parse HEAD)
+
+	    if [ "$rev" = "$CURRENT_HASH" ]; then
+		echo 'unchanged'
+		return ;
+	    fi
+	fi
     fi
+
+    echo -n 'rm old, '
+    rm -rf "$target"
 
     echo -n 'clone, '
     git clone --quiet --no-checkout "$url" "$target"
     ( cd "$target" && git checkout --quiet "$rev" && git reset --quiet --hard "$rev" )
-
-    echo -n 'rm .git, '
-    ( cd "$target" && rm -rf .git )
 
     echo -n 'rm vendor, '
     ( cd "$target" && rm -rf vendor Godeps/_workspace )

--- a/nanocloud/Dockerfile
+++ b/nanocloud/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/github.com/Nanocloud/community/nanocloud
 
 COPY install.sh /tmp/install.sh
 RUN cd /tmp && ./install.sh
-RUN cp -a /tmp/vendor //go/src/github.com/Nanocloud/community/nanocloud/
+RUN cp -a /tmp/vendor /go/src/github.com/Nanocloud/community/nanocloud/
 
 COPY ./ /go/src/github.com/Nanocloud/community/nanocloud
 

--- a/nanocloud/Dockerfile
+++ b/nanocloud/Dockerfile
@@ -4,10 +4,16 @@ MAINTAINER \
   Olivier Berthonneau <olivier.berthonneau@nanocloud.com> \
   William Riancho <william.riancho@nanocloud.com>
 
-COPY ./ /go/src/github.com/Nanocloud/community/nanocloud
+RUN mkdir -p /go/src/github.com/Nanocloud/community/nanocloud
 WORKDIR /go/src/github.com/Nanocloud/community/nanocloud
 
-RUN ./install.sh && go build
+COPY install.sh /tmp/install.sh
+RUN cd /tmp && ./install.sh
+RUN cp -a /tmp/vendor //go/src/github.com/Nanocloud/community/nanocloud/
+
+COPY ./ /go/src/github.com/Nanocloud/community/nanocloud
+
+RUN go build
 
 EXPOSE 8080
 CMD ["./nanocloud"]

--- a/nanocloud/install.sh
+++ b/nanocloud/install.sh
@@ -31,16 +31,23 @@ clone() {
     echo -n "$pkg @ $rev: "
 
     if [ -d "$target" ]; then
-        echo -n 'rm old, '
-        rm -rf "$target"
+
+	if [ "$rev" != "master" ]; then
+	    CURRENT_HASH=$(cd "$target" ; git rev-parse HEAD)
+
+	    if [ "$rev" = "$CURRENT_HASH" ]; then
+		echo 'unchanged'
+		return ;
+	    fi
+	fi
     fi
+
+    echo -n 'rm old, '
+    rm -rf "$target"
 
     echo -n 'clone, '
     git clone --quiet --no-checkout "$url" "$target"
     ( cd "$target" && git checkout --quiet "$rev" && git reset --quiet --hard "$rev" )
-
-    echo -n 'rm .git, '
-    ( cd "$target" && rm -rf .git )
 
     echo -n 'rm vendor, '
     ( cd "$target" && rm -rf vendor Godeps/_workspace )


### PR DESCRIPTION
Run ./install.sh in upper layers for nanocloud-backend and iaas-module.
Modify ./install.sh to ignore already downloaded package if hash did not change.
