### PR TITLE
Bugfix: After retrying a connection, the vdi froze and keyboard/mouse did not work

### DIFF
--- a/webapp/app/components/remote-session/component.js
+++ b/webapp/app/components/remote-session/component.js
@@ -37,16 +37,21 @@ export default Ember.Component.extend({
     guacamole.then((guacData) => {
 
       guacData.tunnel.onerror = function(status) {
+
+        this.get('element').removeChild(guacData.guacamole.getDisplay().getElement());
         var message = "Opening a WebSocketTunnel has failed";
         var code = getKeyFromVal(Guacamole.Status.Code, status.code);
         if (code !== -1) {
           message += " - " + code;
         }
         this.get('remoteSession').stateChanged(this.get('remoteSession.STATE_DISCONNECTED'), true, message);
+        this.get('remoteSession').disconnectSession(this.get('connectionName'));
         this.sendAction('onError', {
           error : true,
           message: "You have been disconnected due to some error"
         });
+      
+
       }.bind(this);
       let guac = guacData.guacamole;
 
@@ -97,6 +102,8 @@ export default Ember.Component.extend({
 
       this.get('element').appendChild(guac.getDisplay().getElement());
 
+
+      this.get('remoteSession').keyboardAttach(this.get('connectionName'));
       let mouse = new window.Guacamole.Mouse(guac.getDisplay().getElement());
       let display = guac.getDisplay();
       window.onresize = function() {

--- a/webapp/app/components/remote-session/component.js
+++ b/webapp/app/components/remote-session/component.js
@@ -37,7 +37,6 @@ export default Ember.Component.extend({
     guacamole.then((guacData) => {
 
       guacData.tunnel.onerror = function(status) {
-
         this.get('element').removeChild(guacData.guacamole.getDisplay().getElement());
         var message = "Opening a WebSocketTunnel has failed";
         var code = getKeyFromVal(Guacamole.Status.Code, status.code);
@@ -50,8 +49,6 @@ export default Ember.Component.extend({
           error : true,
           message: "You have been disconnected due to some error"
         });
-      
-
       }.bind(this);
       let guac = guacData.guacamole;
 
@@ -101,7 +98,6 @@ export default Ember.Component.extend({
       }.bind(this);
 
       this.get('element').appendChild(guac.getDisplay().getElement());
-
 
       this.get('remoteSession').keyboardAttach(this.get('connectionName'));
       let mouse = new window.Guacamole.Mouse(guac.getDisplay().getElement());

--- a/webapp/app/remote-session/service.js
+++ b/webapp/app/remote-session/service.js
@@ -74,7 +74,6 @@ export default Ember.Service.extend(Ember.Evented, {
         tunnel
       );
       this.set('openedGuacSession.' + name, Ember.Object.create({ guac : guacamole }));
-      this.keyboardAttach(name);
 
       return  {
         tunnel : tunnel,

--- a/webapp/app/remote-session/service.js
+++ b/webapp/app/remote-session/service.js
@@ -146,6 +146,7 @@ export default Ember.Service.extend(Ember.Evented, {
     this.pauseInputs(name);
     if (this.get('openedGuacSession')[name]) {
       this.get('openedGuacSession')[name].guac.disconnect();
+      delete this.get('openedGuacSession')[name];
     }
   },
 


### PR DESCRIPTION
When an errors occurs, the guac element in DOM is not removed so when a new connection is being set, it get positioned behind the old guac element which don't respond to user input.
- when closing a guacamole session, make sure it is also been removed from openedGuacSession list.
- attach keyboard event in remote-session component instead of service
- remove the old guac element from DOM when an error occurs
