### PR TITLE
Bugfix: An error 'undefined objectAt' appears when there is no machine

### DIFF
--- a/webapp/app/protected/machines/index/controller.js
+++ b/webapp/app/protected/machines/index/controller.js
@@ -10,7 +10,8 @@ export default Ember.Controller.extend({
   }),
 
   driverName : Ember.computed(function() {
-    return this.get('drivers').objectAt(0).id;
+    let machineDriver =  this.get('drivers');
+    return machineDriver ? machineDriver.objectAt(0).id : null;
   }),
 
   isConfigurable : function() {


### PR DESCRIPTION
- handle the case when machine-driver return an empty array
