### PR TITLE
Rename virtual machine boot message

### DIFF
--- a/webapp/app/helpers/state-machine.js
+++ b/webapp/app/helpers/state-machine.js
@@ -7,7 +7,7 @@ export function stateMachine([val]/*, hash*/) {
     down: "Offline",
     up: "Online",
     terminated: "Terminated",
-    booting: "Booting in progress",
+    booting: "Boot in progress",
     downloading: "Downloading",
   };
 


### PR DESCRIPTION
When a Virtual Machine is booting, the status was renamed "Boot in progress"
