### PR TITLE
Store user storages in /home

### DIFF
--- a/plaza/routes/files/files.go
+++ b/plaza/routes/files/files.go
@@ -24,6 +24,7 @@ package files
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -42,26 +43,11 @@ type file_t struct {
 	Attributes map[string]interface{} `json:"attributes"`
 }
 
-var kUploadDir string
-
 func Post(w http.ResponseWriter, r *http.Request) {
-	sam := r.URL.Query()["sam"][0]
-	userId := r.URL.Query()["userId"][0]
+	username := r.URL.Query()["username"][0]
 	filename := r.URL.Query()["filename"][0]
 
-	kUploadDir = getUploadDir(sam, userId)
-	if _, err := os.Stat(kUploadDir); err != nil {
-		if os.IsNotExist(err) {
-			err := os.MkdirAll(kUploadDir, 0711)
-			if err != nil {
-				log.Error(err)
-				http.Error(w, "Unable to create upload directory", http.StatusInternalServerError)
-				return
-			}
-		}
-	}
-
-	dst, err := os.Create(path.Join(kUploadDir, filename))
+	dst, err := os.Create(fmt.Sprintf("/home/%s/%s", username, filename))
 	if err != nil {
 		log.Error(err)
 		http.Error(w, "Unable to create destination file", http.StatusInternalServerError)

--- a/plaza/routes/files/files_posix.go
+++ b/plaza/routes/files/files_posix.go
@@ -45,11 +45,3 @@ func loadFileId(filepath string) (string, error) {
 func isFileHidden(file os.FileInfo) bool {
 	return file.Name()[0] == '.'
 }
-
-func getUploadDir(sam string, userId string) string {
-	plazaDir := os.Getenv("PLAZA_USER_DIR")
-	if plazaDir == "" {
-		plazaDir = "/opt/Users/%s"
-	}
-	return fmt.Sprintf(plazaDir, "u"+userId[:20])
-}


### PR DESCRIPTION
Put user's files in /home. This lower the impact of the `PLAZA_USER_DIR` that should be removed in the futur.
