### PR TITLE
Logout menu, put email if we have no lastname or firstname

### DIFF
--- a/webapp/app/protected/template.hbs
+++ b/webapp/app/protected/template.hbs
@@ -99,7 +99,7 @@
         <li class="nav-item">
           <div class="dropdown logout-dropdown">
             <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown">
-              {{session.user.firstName}} {{session.user.lastName}}
+              {{session.user.fullName}}
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu">

--- a/webapp/app/user/model.js
+++ b/webapp/app/user/model.js
@@ -47,7 +47,11 @@ export default DS.Model.extend(Validations, {
   signupDate: DS.attr('number'),
 
   fullName: function() {
-    return `${this.get('firstName')}  ${this.get('lastName')}`;
+    if (this.get('firstName') && this.get('lastName')) {
+      return `${this.get('firstName')} ${this.get('lastName')}`;
+    }
+    let email = this.get('email');
+    return email ? email : "Unknown user";
   }.property('firstName', 'lastName'),
   isNotAdmin: function() {
     return !this.get('isAdmin');


### PR DESCRIPTION
User fullName is now being used in logout menu to display user's name or its email if there's no name.
