### PR TITLE
On field edit, there are some artifact when mouse hover

### DIFF
--- a/webapp/app/components/app-item/template.hbs
+++ b/webapp/app/components/app-item/template.hbs
@@ -1,5 +1,5 @@
 {{#unless isUnpublished}}
-  <div class='app-item-block link {{ unless isEditing "hover-enabled" }}' {{ action "toggleSingleTab" application.alias }}>
+  <div class='app-item-block {{ unless isEditing "hover-enabled" }}' {{ action "toggleSingleTab" application.alias }}>
     <div class='app-item part1'>
       {{#if application.iconContent}}
         <img class='applications-icon' src="data:image/png;base64, {{ application.iconContent}}">

--- a/webapp/app/components/edit-text/template.hbs
+++ b/webapp/app/components/edit-text/template.hbs
@@ -6,10 +6,10 @@
         {{input class='edit-input-text' type=getInputType value=confirmInput placeholder=confirmInputPlaceholder enter="submit" }}
       {{/if}}
       <div class='controls-wrapper'>
-        <span class="icon link" {{ action "submit" bubbles=false }}>
+        <span class="icon icon_link clickable" {{ action "submit" bubbles=false }}>
           <i class="material-icons">done</i>
         </span>
-        <span class="icon link close_icon" {{ action "cancel" bubbles=false }}>
+        <span class="icon icon_link clickable close_icon" {{ action "cancel" bubbles=false }}>
           <i class="material-icons">clear</i>
         </span>
       </div>

--- a/webapp/app/styles/applications.scss
+++ b/webapp/app/styles/applications.scss
@@ -17,8 +17,8 @@
   color: $blue-default;
   font-size: $font-size-root;
 
-  & .link:hover{
-    text-decoration: underline;
+  &.link:hover {
+    text-decoration: inherit;
   }
 
   & td .icon i {


### PR DESCRIPTION
Artefact occurs on edit-text component. on mouse hover, "link" class is applied to the input text and the icon which set text-decoration to "underline". To avoid that behavior, link class has been replaced by "clickable icon_link" which does the same effect.
