### PR TITLE
Handle bad driver configuration.

### DIFF
--- a/nanocloud/connectors/vms/vms.go
+++ b/nanocloud/connectors/vms/vms.go
@@ -23,6 +23,8 @@
 package vms
 
 import (
+	log "github.com/Sirupsen/logrus"
+
 	"github.com/Nanocloud/community/nanocloud/vms"
 )
 
@@ -38,6 +40,9 @@ const (
 var vm *vms.VM
 
 func SetVM(v *vms.VM) {
+	if (*v) == nil {
+		log.Fatal("Driver error: Please fix your configuration")
+	}
 	vm = v
 }
 


### PR DESCRIPTION
Show a fatal log and exist program properly instead of a stack trace when a bad driver configuration is set.
